### PR TITLE
feat(L3,L4): bind a plan's acceptance criteria to the gate that proves them

### DIFF
--- a/.github/workflows/software-factory.yml
+++ b/.github/workflows/software-factory.yml
@@ -31,9 +31,23 @@ jobs:
   hazards:
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth: 0 because the secret scanner diffs against the base commit
+      # on a pull request, and a shallow clone leaves it nothing to diff
+      # against — it then fails with an empty result and no explanation.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Committed secrets
         uses: gitleaks/gitleaks-action@v2
+        # The action refuses to scan a pull request without a token, and says
+        # so only at run time — which is why this repository's first pull
+        # request was the first run to hit it. The two flags stop the action
+        # reaching for permissions this job does not grant, which it does by
+        # posting a comment and then failing 403.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: "false"
+          GITLEAKS_ENABLE_SUMMARY: "false"
       - name: Dependency vulnerabilities
         uses: taiki-e/install-action@cargo-audit
       - run: cargo audit

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -4,7 +4,7 @@
     ".allowed-root-files": "20889fd9828de3c601e63bae4c430692846319df116688c1322bd230bdfc1995",
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
     ".github/workflows/software-factory.yml": "3dfa75cb73958bea4761a7cc0385bf2ca59ad14e0968fbab279eb115207ea1bc",
-    ".software-factory/policy.yaml": "dbb79c1305d87747c7efa9d2fdf11cfe17e03a06d7035680e9bf0c9d8a5baa45",
+    ".software-factory/policy.yaml": "bedfe73ac1933c752fb1a86956ff2d7ea2229e117e5bb228b39a23e8bc0049e8",
     ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"
   }
 }

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -3,7 +3,7 @@
   "files": {
     ".allowed-root-files": "20889fd9828de3c601e63bae4c430692846319df116688c1322bd230bdfc1995",
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
-    ".github/workflows/software-factory.yml": "3dfa75cb73958bea4761a7cc0385bf2ca59ad14e0968fbab279eb115207ea1bc",
+    ".github/workflows/software-factory.yml": "348ac2ea2fe74161ac307a55583fb337b811007b81772ed719cabadbeb701a0d",
     ".software-factory/policy.yaml": "bedfe73ac1933c752fb1a86956ff2d7ea2229e117e5bb228b39a23e8bc0049e8",
     ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"
   }

--- a/.software-factory/mutations/L3.GATE_COVERS_THE_PLAN/.software-factory/policy.yaml
+++ b/.software-factory/mutations/L3.GATE_COVERS_THE_PLAN/.software-factory/policy.yaml
@@ -1,0 +1,16 @@
+# Generated mutation fixture for L3.GATE_COVERS_THE_PLAN. It is supposed to fail.
+version: 1
+project:
+  name: mutation-L3.GATE_COVERS_THE_PLAN
+  languages: [python, typescript, go, rust]
+docs:
+  scan: ["docs/**/*.md"]
+gates:
+  checkout:
+    activation: ["src/checkout/**"]
+    evidence: "evidence/checkout.json"
+    plan: "plans/rewrite-checkout.md"
+    required_assertions: ["api.ledger_balanced"]
+rules:
+  L3.GATE_COVERS_THE_PLAN:
+    enabled: true

--- a/.software-factory/mutations/L3.GATE_COVERS_THE_PLAN/plans/rewrite-checkout.md
+++ b/.software-factory/mutations/L3.GATE_COVERS_THE_PLAN/plans/rewrite-checkout.md
@@ -1,0 +1,8 @@
+# Rewrite checkout
+
+Exit condition: the new checkout serves live traffic.
+
+## Acceptance criteria
+
+- [ ] A guest can complete a purchase without an account.
+      (proof: assertion:api.guest_checkout_completed)

--- a/.software-factory/mutations/L4.PLAN_CRITERION_NAMES_ITS_CHECK/.software-factory/policy.yaml
+++ b/.software-factory/mutations/L4.PLAN_CRITERION_NAMES_ITS_CHECK/.software-factory/policy.yaml
@@ -1,0 +1,11 @@
+# Generated mutation fixture for L4.PLAN_CRITERION_NAMES_ITS_CHECK. It is supposed to fail.
+version: 1
+project:
+  name: mutation-L4.PLAN_CRITERION_NAMES_ITS_CHECK
+  languages: [python, typescript, go, rust]
+docs:
+  scan: ["docs/**/*.md"]
+gates: {}
+rules:
+  L4.PLAN_CRITERION_NAMES_ITS_CHECK:
+    enabled: true

--- a/.software-factory/mutations/L4.PLAN_CRITERION_NAMES_ITS_CHECK/plans/rewrite-checkout.md
+++ b/.software-factory/mutations/L4.PLAN_CRITERION_NAMES_ITS_CHECK/plans/rewrite-checkout.md
@@ -1,0 +1,9 @@
+# Rewrite checkout
+
+Exit condition: the new checkout serves live traffic.
+
+## Acceptance criteria
+
+- [ ] A guest can complete a purchase without an account.
+- [ ] Refunds reconcile against the ledger.
+      (proof: test:tests/test_refunds.py)

--- a/.software-factory/policy.yaml
+++ b/.software-factory/policy.yaml
@@ -97,6 +97,9 @@ rules:
   # L3 — A gate activated by touched paths needs digest-verified, non-stale evidence
   L3.GATE_HAS_FRESH_EVIDENCE:
     enabled: true
+  # L3 — A gate requires every check its plan's criteria name
+  L3.GATE_COVERS_THE_PLAN:
+    enabled: true
   # L4 — Repo-relative documentation links resolve
   L4.DOC_LINKS_RESOLVE:
     enabled: true
@@ -105,6 +108,9 @@ rules:
     enabled: true
   # L4 — Every plan declares its exit condition and sits in the execution order
   L4.PLAN_DECLARES_EXIT_CONDITION:
+    enabled: true
+  # L4 — Every acceptance criterion names the check that proves it
+  L4.PLAN_CRITERION_NAMES_ITS_CHECK:
     enabled: true
   # L4 — New top-level files are declared before they appear
   L4.ROOT_FILES_ARE_DECLARED:

--- a/catalog/L3/gate-covers-the-plan.yaml
+++ b/catalog/L3/gate-covers-the-plan.yaml
@@ -1,0 +1,26 @@
+id: L3.GATE_COVERS_THE_PLAN
+layer: L3
+title: A gate requires every check its plan's criteria name
+statement: >-
+  When a gate names a `plan`, every `(proof: assertion:ID)` a criterion in that
+  plan carries appears in that gate's `required_assertions`.
+severity: critical
+why: >-
+  This is the half `L3.GATE_HAS_FRESH_EVIDENCE` cannot see. That rule verifies
+  the evidence for whatever the gate demanded; it has no way to know the gate
+  demanded less than the plan promised. An assertion no run is required to carry
+  reads exactly like coverage — the criterion cites a proof, the gate is green,
+  and the proof never ran. Declaring the list in policy rather than only in the
+  manifest is the same argument one level down: a manifest is written by the
+  change under review, so a run that under-declares its own obligations passes.
+  Policy sits outside the candidate implementation. The two lists are unioned, so
+  a manifest may add an assertion but never drop one.
+fix: >-
+  Add the assertion to `gates.<name>.required_assertions`, or change the
+  criterion to name a check that does run. If the criterion cannot be proven in
+  this gate, mark it `deferred:` or `unspecified:` and let the debt be visible
+  instead of implied.
+ratchet: none
+check:
+  kind: cadence
+  mode: gate_coverage

--- a/catalog/L4/plan-criterion-names-its-check.yaml
+++ b/catalog/L4/plan-criterion-names-its-check.yaml
@@ -1,0 +1,31 @@
+id: L4.PLAN_CRITERION_NAMES_ITS_CHECK
+layer: L4
+title: Every acceptance criterion names the check that proves it
+severity: medium
+statement: >-
+  Each acceptance criterion written as a checkbox in a plan closes with a proof
+  marker — `(proof: assertion:ID)`, `(proof: test:PATH)`,
+  `(proof: deferred:REASON)` or `(proof: unspecified:REASON)`.
+why: >-
+  A plan states its criteria in prose and the gate enforces a list of checks,
+  and nothing joins the two. That gap does not need anybody to be dishonest to
+  become expensive: a criterion is promised, the gate never covered it, the plan
+  records the gap on some line in the middle of a long document, and the only
+  way to learn a phase's real status is to re-read the phase. Naming the check
+  inside the criterion makes the join mechanical, and forces the decision at the
+  moment of writing rather than at the moment someone asks. The two debt kinds
+  are the load-bearing half — `deferred` for a criterion that is not built and
+  `unspecified` for one no check has been designed for are both legitimate, and
+  declaring them is what turns an admission into something greppable.
+fix: >-
+  Append the marker naming what proves the criterion. If nothing proves it yet,
+  say which: `deferred:` when the criterion is not built, `unspecified:` when no
+  check has been designed for it. Both take a reason, and both are a supported
+  answer — an unmarked criterion is not.
+ratchet: allowlist
+check:
+  kind: cadence
+  mode: plan_criteria
+defaults:
+  scope:
+    - "plans/*.md"

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -154,6 +154,16 @@ Compared with the revision under review, no rule may be disabled or removed, no 
 
 ## L3 — Effect: a real actor achieved the outcome
 
+### L3.GATE_COVERS_THE_PLAN
+
+**A gate requires every check its plan's criteria name**
+
+When a gate names a `plan`, every `(proof: assertion:ID)` a criterion in that plan carries appears in that gate's `required_assertions`.
+
+**Why.** This is the half `L3.GATE_HAS_FRESH_EVIDENCE` cannot see. That rule verifies the evidence for whatever the gate demanded; it has no way to know the gate demanded less than the plan promised. An assertion no run is required to carry reads exactly like coverage — the criterion cites a proof, the gate is green, and the proof never ran. Declaring the list in policy rather than only in the manifest is the same argument one level down: a manifest is written by the change under review, so a run that under-declares its own obligations passes. Policy sits outside the candidate implementation. The two lists are unioned, so a manifest may add an assertion but never drop one.
+
+**Fix.** Add the assertion to `gates.<name>.required_assertions`, or change the criterion to name a check that does run. If the criterion cannot be proven in this gate, mark it `deferred:` or `unspecified:` and let the debt be visible instead of implied.
+
 ### L3.GATE_HAS_FRESH_EVIDENCE
 
 **A gate activated by touched paths needs digest-verified, non-stale evidence**
@@ -185,6 +195,16 @@ Each enabled rule is referenced at least once from documentation by its id, and 
 **Why.** A check with no prose is a wall an agent hits with no way to tell whether it is protecting something or just old. A prose rule with no check is advice that drifts the day someone ignores it. Requiring the pair in both directions is what keeps the documentation and the enforcement from becoming two separate, disagreeing standards — which is the failure this whole method exists to prevent.
 
 **Fix.** Cite the rule id in the document that explains the decision, or write that document. To retire a rule, disable it in policy and remove the citation in the same commit.
+
+### L4.PLAN_CRITERION_NAMES_ITS_CHECK
+
+**Every acceptance criterion names the check that proves it**
+
+Each acceptance criterion written as a checkbox in a plan closes with a proof marker — `(proof: assertion:ID)`, `(proof: test:PATH)`, `(proof: deferred:REASON)` or `(proof: unspecified:REASON)`.
+
+**Why.** A plan states its criteria in prose and the gate enforces a list of checks, and nothing joins the two. That gap does not need anybody to be dishonest to become expensive: a criterion is promised, the gate never covered it, the plan records the gap on some line in the middle of a long document, and the only way to learn a phase's real status is to re-read the phase. Naming the check inside the criterion makes the join mechanical, and forces the decision at the moment of writing rather than at the moment someone asks. The two debt kinds are the load-bearing half — `deferred` for a criterion that is not built and `unspecified` for one no check has been designed for are both legitimate, and declaring them is what turns an admission into something greppable.
+
+**Fix.** Append the marker naming what proves the criterion. If nothing proves it yet, say which: `deferred:` when the criterion is not built, `unspecified:` when no check has been designed for it. Both take a reason, and both are a supported answer — an unmarked criterion is not.
 
 ### L4.PLAN_DECLARES_EXIT_CONDITION
 

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -113,6 +113,10 @@ pub enum CadenceMode {
     RuleCitations,
     /// Every plan declares an exit condition and sits in the execution order.
     PlanCadence,
+    /// Every acceptance criterion in a plan names the check that proves it.
+    PlanCriteria,
+    /// Every check a plan's criteria name is one its gate actually requires.
+    GateCoverage,
     /// Every enabled rule has a mutation fixture that proves the check fires.
     MutationCoverage,
     /// No enabled rule is configured so it cannot produce a finding.
@@ -210,10 +214,12 @@ const BUILTIN: &[(&str, &str)] = &[
     ("L2/dependencies-change-deliberately.yaml", include_str!("../catalog/L2/dependencies-change-deliberately.yaml")),
     ("L2/no-permanent-exception.yaml", include_str!("../catalog/L2/no-permanent-exception.yaml")),
     ("L3/gate-has-fresh-evidence.yaml", include_str!("../catalog/L3/gate-has-fresh-evidence.yaml")),
+    ("L3/gate-covers-the-plan.yaml", include_str!("../catalog/L3/gate-covers-the-plan.yaml")),
     ("L4/doc-links-resolve.yaml", include_str!("../catalog/L4/doc-links-resolve.yaml")),
     ("L4/root-files-are-declared.yaml", include_str!("../catalog/L4/root-files-are-declared.yaml")),
     ("L4/every-rule-has-a-why.yaml", include_str!("../catalog/L4/every-rule-has-a-why.yaml")),
     ("L4/plan-declares-exit-condition.yaml", include_str!("../catalog/L4/plan-declares-exit-condition.yaml")),
+    ("L4/plan-criterion-names-its-check.yaml", include_str!("../catalog/L4/plan-criterion-names-its-check.yaml")),
     ("L5/every-check-has-a-mutation-test.yaml", include_str!("../catalog/L5/every-check-has-a-mutation-test.yaml")),
     ("L5/no-inert-rule.yaml", include_str!("../catalog/L5/no-inert-rule.yaml")),
     ("L2/factory-config-is-locked.yaml", include_str!("../catalog/L2/factory-config-is-locked.yaml")),

--- a/src/checks/cadence.rs
+++ b/src/checks/cadence.rs
@@ -19,6 +19,8 @@ pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx, mode: CadenceMode) -> Result<
         CadenceMode::RootFiles => root_files(rule, opts, ctx),
         CadenceMode::RuleCitations => rule_citations(rule, opts, ctx),
         CadenceMode::PlanCadence => plan_cadence(rule, opts, ctx),
+        CadenceMode::PlanCriteria => plan_criteria(rule, opts, ctx),
+        CadenceMode::GateCoverage => gate_coverage(rule, ctx),
         CadenceMode::MutationCoverage => mutation_coverage(rule, ctx),
         CadenceMode::InertRules => inert_rules(rule, ctx),
     }
@@ -296,6 +298,182 @@ fn mutation_coverage(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
                     format!("{id} is enabled with nothing proving it ever fires"),
                 )
                 .expected(format!("a mutation fixture at {FIXTURES_DIR}/{id}/")),
+            );
+        }
+    }
+    Ok(findings)
+}
+
+/// The proof marker a criterion closes with, e.g.
+/// `(proof: assertion:api.feedback_linked_to_acquisition)`.
+///
+/// Anchored at the end of the joined item on purpose: a marker in the middle of
+/// a sentence would name a proof for a clause rather than for the criterion.
+const CRITERION_MARKER: &str = r"\(proof:\s*([a-z_]+)\s*:\s*([^)]*)\)\s*$";
+
+/// `assertion` and `test` name something that runs. `deferred` says the
+/// criterion is not built and `unspecified` says no check has been designed for
+/// it — both are legitimate to declare and both are debt, which is the point:
+/// the admission becomes a line someone can grep instead of a sentence buried
+/// in a long document.
+const PROOF_KINDS: &[&str] = &["assertion", "test", "deferred", "unspecified"];
+
+struct Criterion {
+    line: usize,
+    text: String,
+    kind: Option<String>,
+    value: String,
+}
+
+impl Criterion {
+    /// A marker that parsed, named a known kind, and carried a value.
+    fn is_complete(&self) -> bool {
+        match &self.kind {
+            Some(kind) => PROOF_KINDS.contains(&kind.as_str()) && !self.value.is_empty(),
+            None => false,
+        }
+    }
+}
+
+/// Pull every checkbox criterion out of a plan, with the marker it closes with.
+///
+/// Criteria wrap, so the marker is looked for in the joined item rather than on
+/// the checkbox line. A checkbox is the definition of a criterion because plans
+/// spell the surrounding heading four different ways — "Acceptance criteria",
+/// "Acceptance gates", "Gates", "Rollout/acceptance additions" — and a rule that
+/// matches heading names is a rule about prose style.
+fn parse_criteria(body: &str) -> Result<Vec<Criterion>> {
+    let checkbox = Regex::new(r"^\s*-\s\[[ xX]\]\s*(.*)$")?;
+    let continuation = Regex::new(r"^\s+\S")?;
+    let marker = Regex::new(CRITERION_MARKER)?;
+
+    let lines: Vec<&str> = body.lines().collect();
+    let mut criteria = Vec::new();
+    let mut index = 0;
+    while index < lines.len() {
+        let Some(opened) = checkbox.captures(lines[index]) else {
+            index += 1;
+            continue;
+        };
+        let line = index + 1;
+        let mut parts = vec![opened[1].trim().to_string()];
+        index += 1;
+        while index < lines.len()
+            && continuation.is_match(lines[index])
+            && !checkbox.is_match(lines[index])
+        {
+            parts.push(lines[index].trim().to_string());
+            index += 1;
+        }
+        let joined = parts.iter().filter(|p| !p.is_empty()).cloned().collect::<Vec<_>>().join(" ");
+        match marker.captures(&joined) {
+            Some(found) => {
+                let whole = found.get(0).map(|m| m.start()).unwrap_or(joined.len());
+                criteria.push(Criterion {
+                    line,
+                    text: joined[..whole].trim().to_string(),
+                    kind: Some(found[1].to_string()),
+                    value: found[2].trim().to_string(),
+                });
+            }
+            None => criteria.push(Criterion { line, text: joined, kind: None, value: String::new() }),
+        }
+    }
+    Ok(criteria)
+}
+
+/// `L4.PLAN_CRITERION_NAMES_ITS_CHECK`: a criterion with nothing that proves it.
+///
+/// A plan states criteria in prose and the gate enforces a list of assertions.
+/// Where nothing joins the two, both can be honest and the pair still says
+/// nothing: the criterion is promised, the gate never covered it, and the only
+/// place that records the gap is the plan nobody re-reads.
+fn plan_criteria(rule: &Rule, opts: &Options, ctx: &Ctx) -> Result<Vec<Finding>> {
+    let mut findings = Vec::new();
+    for file in scan::select(ctx.files, &opts.scope, &opts.exclude)? {
+        let Ok(body) = std::fs::read_to_string(&file.abs) else {
+            continue;
+        };
+        for criterion in parse_criteria(&body)? {
+            if criterion.is_complete() {
+                continue;
+            }
+            let detail = match &criterion.kind {
+                None => "names no check that would prove it".to_string(),
+                Some(kind) if !PROOF_KINDS.contains(&kind.as_str()) => {
+                    format!("names unknown proof kind `{kind}`")
+                }
+                Some(kind) => format!("carries a `{kind}` marker with no value"),
+            };
+            findings.push(
+                Finding::new(
+                    &rule.id,
+                    rule.severity,
+                    format!("{}:{}", file.rel, criterion.line),
+                    format!("unproven:{}:{}", file.rel, criterion.line),
+                    format!("this acceptance criterion {detail}"),
+                )
+                .expected(
+                    "a trailing (proof: assertion:ID | test:PATH | deferred:REASON \
+                     | unspecified:REASON)",
+                )
+                .actual(criterion.text),
+            );
+        }
+    }
+    Ok(findings)
+}
+
+/// `L3.GATE_COVERS_THE_PLAN`: the plan names a proof the gate never asks for.
+///
+/// This is the half `L3.GATE_HAS_FRESH_EVIDENCE` cannot see. That rule verifies
+/// the evidence for what the gate demanded; it has no way to know the gate
+/// demanded less than the plan promised. An assertion no run is required to
+/// carry reads exactly like coverage.
+fn gate_coverage(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
+    let mut findings = Vec::new();
+    for (name, gate) in &ctx.policy.gates {
+        let Some(plan) = &gate.plan else {
+            continue;
+        };
+        let path = ctx.root.join(plan);
+        let Ok(body) = std::fs::read_to_string(&path) else {
+            findings.push(
+                Finding::new(
+                    &rule.id,
+                    rule.severity,
+                    plan.clone(),
+                    format!("missing-plan:{name}"),
+                    format!("gate `{name}` names a plan that does not exist"),
+                )
+                .expected(plan.clone()),
+            );
+            continue;
+        };
+        for criterion in parse_criteria(&body)? {
+            if criterion.kind.as_deref() != Some("assertion") {
+                continue;
+            }
+            if gate.required_assertions.contains(&criterion.value) {
+                continue;
+            }
+            findings.push(
+                Finding::new(
+                    &rule.id,
+                    rule.severity,
+                    format!("{plan}:{}", criterion.line),
+                    format!("uncovered:{name}:{}", criterion.value),
+                    format!(
+                        "this criterion is proven by `{}`, which gate `{name}` does not require",
+                        criterion.value
+                    ),
+                )
+                .expected(format!("`{}` in gates.{name}.required_assertions", criterion.value))
+                .actual(if gate.required_assertions.is_empty() {
+                    "the gate requires no assertions at all".to_string()
+                } else {
+                    gate.required_assertions.join(", ")
+                }),
             );
         }
     }

--- a/src/checks/evidence.rs
+++ b/src/checks/evidence.rs
@@ -282,14 +282,37 @@ fn check_run(
             .actual(format!("scenario {} status {}", report.scenario, report.status)),
         ]);
     }
-    let mut findings = check_assertions(rule, &key, run, &report);
+    let mut findings = check_assertions(rule, &key, gate, run, &report);
     findings.extend(check_goal_fidelity(rule, opts, &key, run, &report));
     Ok(findings)
 }
 
-fn check_assertions(rule: &Rule, key: &str, run: &Run, report: &Report) -> Vec<Finding> {
-    let mut findings = Vec::new();
+/// The union of what policy demands and what the manifest admits it owed.
+///
+/// A manifest is written by the change under review, so a list that lives only
+/// there is a run declaring its own obligations — under-declare, and the gate
+/// passes on a subset of what it was for. Policy sits outside the candidate
+/// implementation, so unioning the two means a manifest can add an assertion
+/// but never drop one.
+fn required_assertions(gate: &Gate, run: &Run) -> Vec<String> {
+    let mut all: Vec<String> = gate.required_assertions.clone();
     for assertion in &run.required_assertions {
+        if !all.contains(assertion) {
+            all.push(assertion.clone());
+        }
+    }
+    all
+}
+
+fn check_assertions(
+    rule: &Rule,
+    key: &str,
+    gate: &Gate,
+    run: &Run,
+    report: &Report,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    for assertion in &required_assertions(gate, run) {
         match report.assertions.iter().find(|a| &a.kind == assertion) {
             None => findings.push(
                 fail(

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -223,6 +223,30 @@ pub const FIXTURES: &[Fixture] = &[
         ],
     },
     Fixture {
+        rule: "L4.PLAN_CRITERION_NAMES_ITS_CHECK",
+        policy_extra: "",
+        extra_rules: "",
+        files: &[(
+            "plans/rewrite-checkout.md",
+            "# Rewrite checkout\n\nExit condition: the new checkout serves live traffic.\n\n\
+             ## Acceptance criteria\n\n\
+             - [ ] A guest can complete a purchase without an account.\n\
+             - [ ] Refunds reconcile against the ledger.\n      (proof: test:tests/test_refunds.py)\n",
+        )],
+    },
+    Fixture {
+        rule: "L3.GATE_COVERS_THE_PLAN",
+        policy_extra: "",
+        extra_rules: "",
+        files: &[(
+            "plans/rewrite-checkout.md",
+            "# Rewrite checkout\n\nExit condition: the new checkout serves live traffic.\n\n\
+             ## Acceptance criteria\n\n\
+             - [ ] A guest can complete a purchase without an account.\n      \
+             (proof: assertion:api.guest_checkout_completed)\n",
+        )],
+    },
+    Fixture {
         rule: "L5.EVERY_CHECK_HAS_A_MUTATION_TEST",
         policy_extra: "",
         // A second rule with no fixture of its own is what this must notice.
@@ -338,10 +362,16 @@ const CI_WITHOUT_HAZARD_TOOLS: &str = "name: ci\non: [push]\njobs:\n  test:\n   
 /// The mini-policy a fixture runs under: the target rule, plus whatever the
 /// fixture needs to be a coherent repository.
 pub fn fixture_policy(fixture: &Fixture) -> String {
-    let gates = if fixture.rule == "L3.GATE_HAS_FRESH_EVIDENCE" {
-        "gates:\n  checkout:\n    activation: [\"src/checkout/**\"]\n    evidence: \"evidence/checkout.json\"\n"
-    } else {
-        "gates: {}\n"
+    let gates = match fixture.rule {
+        "L3.GATE_HAS_FRESH_EVIDENCE" => {
+            "gates:\n  checkout:\n    activation: [\"src/checkout/**\"]\n    evidence: \"evidence/checkout.json\"\n"
+        }
+        // A gate that names its plan and requires an assertion the plan does
+        // not cite. The criterion cites a different one, which is the hole.
+        "L3.GATE_COVERS_THE_PLAN" => {
+            "gates:\n  checkout:\n    activation: [\"src/checkout/**\"]\n    evidence: \"evidence/checkout.json\"\n    plan: \"plans/rewrite-checkout.md\"\n    required_assertions: [\"api.ledger_balanced\"]\n"
+        }
+        _ => "gates: {}\n",
     };
     let extra_rule = fixture.extra_rules;
     format!(

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -120,6 +120,18 @@ pub struct Gate {
     pub activation: Vec<String>,
     /// Where the evidence manifest for this gate lives.
     pub evidence: String,
+    /// The plan whose acceptance criteria this gate is supposed to enforce.
+    /// `L3.GATE_COVERS_THE_PLAN` reads the criteria there and requires every
+    /// check they name to appear in `required_assertions` below.
+    #[serde(default)]
+    pub plan: Option<String>,
+    /// Assertions every run of this gate must carry, declared here rather than
+    /// only in the manifest. A manifest states what it owed, so a run that
+    /// under-declares its own obligations passes; policy lives outside the
+    /// candidate implementation and is not editable by the change under
+    /// review. The two lists are unioned — a manifest may add, never subtract.
+    #[serde(default)]
+    pub required_assertions: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
## The gap

`L3.GATE_HAS_FRESH_EVIDENCE` verifies the evidence for whatever a gate demanded. It has no way to know the gate demanded **less than the plan promised**, and nothing else in the catalog closes that.

A plan states criteria in prose, the gate enforces a list, and where nothing joins the two both halves can be honest while the pair says nothing: the criterion is promised, no run ever covered it, and the only record of the gap is a line in the middle of a document nobody re-reads.

Not hypothetical — it cost a real phase a month. An acceptance criterion promised participation without an account, the field shipped hardcoded to the opposite, the plan said so on line 23, and the gate had never been asked to cover it. **No check failed. Nobody lied.** The information had nowhere to be found.

## Two rules

**`L4.PLAN_CRITERION_NAMES_ITS_CHECK`** (medium, ratchet: allowlist) — each checkbox criterion in a plan closes with a marker:

```
- [ ] Refunds reconcile against the ledger.
      (proof: test:tests/test_refunds.py)
```

A checkbox is the definition of a criterion because plans spell the surrounding heading four different ways — "Acceptance criteria", "Acceptance gates", "Gates", "Rollout/acceptance additions" — and a rule that matches heading names is a rule about prose style.

The two debt kinds carry the weight. `deferred` for a criterion that is not built and `unspecified` for one no check has been designed for are both legitimate answers, and declaring one turns an admission into something greppable. An unmarked criterion is not an answer.

**`L3.GATE_COVERS_THE_PLAN`** (critical, ratchet: none) — when a gate names a `plan`, every `(proof: assertion:ID)` in it must appear in that gate's `required_assertions`. An assertion no run is required to carry reads exactly like coverage.

## The `Gate` change, and why it tightens

`Gate` grows `plan: Option<String>` and `required_assertions: Vec<String>`, both `#[serde(default)]`, so no adopter changes.

Moving `required_assertions` into policy is the same argument one level down. The list lived only on `Run` — **inside the manifest, which is written by the change under review.** A run that under-declares its own obligations passed. `check_assertions` now takes the union of policy-side and manifest-side, so a manifest may add an assertion and never drop one. For anyone who leaves the new field empty, behaviour is identical.

## Dogfooding

Both rules are enabled in this repo's own policy, both have mutation fixtures, and `sf verify` proves both fire:

```
✓ L3.GATE_COVERS_THE_PLAN — this criterion is proven by `api.guest_checkout_completed`,
  which gate `checkout` does not require
✓ L4.PLAN_CRITERION_NAMES_ITS_CHECK — this acceptance criterion names no check that would prove it

26/26 enabled rules proven to fire
```

They report nothing against this repository's own three plans, which state no checkbox criteria yet. That is the honest current state, not a configuration accident — the rules only speak about criteria that exist, which is what keeps them safe to enable in a repo that writes plans differently.

## A trap worth recording

`catalog/` is an explicit `include_str!` list in `src/catalog.rs`, the same shape as skills. **Both rules loaded, ran, and were silently invisible to `sf verify` until registered there — and verify reported green the whole time**, because it iterates the catalog it can see. That is the failure mode `AGENTS.md` already warns about for skills; it applies to rules too, and it is arguably worth its own line there.

Related: `L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE` runs `./target/release/sf docs`, so a rule added without `cargo build --release` gets its `docs/rules.md` section silently reverted by the stale binary. Worth knowing before debugging it twice.

## Verification

```
cargo clippy --all-targets -- -D warnings -D dead_code   # clean (CI flags)
cargo build --release --locked                           # clean
sf verify                                                # 26/26 proven to fire
sf check --allow-commands                                # 26 rules, no findings
```

Order of operations followed: `sf fixtures`, `sf docs`, then `sf lock` last. `sf ratchet` was deliberately **not** re-seeded — it only pushed a `review_by` out by one day, which `L2.POLICY_ONLY_TIGHTENS` correctly treats as loosening, and nothing new needed freezing.

## Provenance

Built in `logion-workspace` first, where the same design surfaced 31 real debt criteria across seven phases ([logion-workspace#140](https://github.com/nicolasmelo1/logion-workspace/pull/140)). This is the generic half; what stays there is the proving-ground vocabulary — the evidence-manifest caveat schema and the phase entries themselves.

## Not included

`src/init.rs` has uncommitted changes on this working tree (bandit exclude dirs, gitleaks flags) that predate this work and are unrelated to it. They are deliberately left unstaged.
