### PR TITLE
fix(report): print expected/actual independently in text output

### DIFF
--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -12,6 +12,8 @@ precondition exists. Park it in the second table rather than deleting it.
 
 | 2 | [Keep the generated prose in sync with the catalog](keep-generated-prose-in-sync.md) | A rule whose `fix` names a command `sf` does not accept fails `sf check`, proven by a fixture. |
 
+| 3 | [Text renderer shows `expected` even when `actual` is absent](text-renderer-shows-expected-without-actual.md) | A finding produced by any check that sets `expected` without `actual` shows that field in `sf check`'s text output, proven by the `L4.ROOT_FILES_ARE_DECLARED` mutation fixture and a stray-root-file check naming `.allowed-root-files`. |
+
 ## Parked
 
 | Work | Waiting on |

--- a/plans/text-renderer-shows-expected-without-actual.md
+++ b/plans/text-renderer-shows-expected-without-actual.md
@@ -1,0 +1,63 @@
+# Text renderer shows `expected` even when `actual` is absent
+
+`Report::text()` in `src/report.rs` only prints a finding's `expected`/`actual`
+pair when both are set:
+
+```rust
+if let (Some(expected), Some(actual)) = (&finding.expected, &finding.actual) {
+    out.push_str(&format!("       expected {expected}\n       actual   {actual}\n"));
+}
+```
+
+`root_files()` in `src/checks/cadence.rs` (the check behind
+`L4.ROOT_FILES_ARE_DECLARED`) sets only `.expected(...)` on its finding. The
+JSON renderer has no such gate and always serializes whichever fields are
+`Some`, so the data survives there; the text path — the one a human or an
+agent reads first — silently drops the one string that says what to do about
+the finding. Confirmed on this repository itself: dropping a stray file at
+the root and running `sf check` prints only
+
+```
+    ZZTEMP-probe.md — `ZZTEMP-probe.md` is at the repository root but not declared
+```
+
+while `sf check --format json` for the same finding carries
+`"expected": "an entry in .allowed-root-files, or somewhere with a lifecycle"`.
+Acting on the text finding required disassembling the binary to find the
+allowlist's filename.
+
+This is not one check's bug. Of the 35 `.expected(` call sites across
+`src/checks/*.rs`, 10 never pair it with `.actual(`: eight in
+`src/checks/cadence.rs`, one in `src/checks/evidence.rs`, one in
+`src/checks/lock.rs`. Every one of those ten findings loses its `expected`
+line in text output today. Fixing `root_files()` alone would leave nine more
+checks with the identical silent drop, so the fix belongs in the renderer:
+print `expected` whenever it is `Some`, print `actual` whenever it is `Some`,
+independently, keeping the existing combined layout for findings that set
+both (nothing about that case changes — same two lines, same order, same
+indentation).
+
+Explicitly out of scope for this change: `sf verify`'s `Outcome` has no
+`Serialize` derive and no format flag, and `sf explain`/`sf catalog` have no
+machine-readable output path at all. Both are real gaps; neither shares a root
+cause with this one, and bundling them would make one PR review three
+unrelated surfaces.
+
+**Exit condition:** a finding produced by any check that sets `expected`
+without `actual` (or `actual` without `expected`) shows that field in
+`sf check`'s text output, proven by the `L4.ROOT_FILES_ARE_DECLARED` mutation
+fixture continuing to pass under `sf verify` and by `sf check` naming
+`.allowed-root-files` for a stray root file in this repository.
+
+## Acceptance criteria
+
+- [x] `sf check`'s text output prints `expected` for a finding that sets
+      `expected` alone, matching what `sf check --format json` already showed
+      (proof: test:.software-factory/mutations/L4.ROOT_FILES_ARE_DECLARED/)
+- [x] A finding that sets both `expected` and `actual` keeps rendering the
+      existing two-line combined layout unchanged
+      (proof: test:.software-factory/mutations/L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE/)
+- [ ] `sf verify`'s `Outcome` gains a `Serialize` derive and a format flag
+      (proof: deferred:tracked as a separate PR, not this one)
+- [ ] `sf explain`/`sf catalog` gain a machine-readable output path
+      (proof: deferred:tracked as a separate PR, not this one)

--- a/src/report.rs
+++ b/src/report.rs
@@ -51,8 +51,11 @@ impl Report {
             }
             for finding in findings {
                 out.push_str(&format!("    {} — {}\n", finding.location, finding.message));
-                if let (Some(expected), Some(actual)) = (&finding.expected, &finding.actual) {
-                    out.push_str(&format!("       expected {expected}\n       actual   {actual}\n"));
+                if let Some(expected) = &finding.expected {
+                    out.push_str(&format!("       expected {expected}\n"));
+                }
+                if let Some(actual) = &finding.actual {
+                    out.push_str(&format!("       actual   {actual}\n"));
                 }
             }
         }


### PR DESCRIPTION
## Problem

`Report::text()` in `src/report.rs` only printed a finding's `expected`/`actual` pair when **both** were set. Of the 35 `.expected(` call sites across `src/checks/*.rs`, 10 never pair it with `.actual(` (eight in `cadence.rs`, one in `evidence.rs`, one in `lock.rs`) — every one of those findings silently lost its `expected` line in text output, while `--format json` carried the field fine.

Confirmed on this repository itself: `L4.ROOT_FILES_ARE_DECLARED` printed only the violation, and acting on the text finding required disassembling the binary to discover the allowlist's filename (`.allowed-root-files`).

## Fix

The renderer now prints `expected` whenever it is `Some` and `actual` whenever it is `Some`, independently. Findings that set both keep the exact existing two-line combined layout — same order, same indentation.

## Verification

- `sf verify`: 27/27 enabled rules proven to fire (mutation fixtures unchanged).
- `sf check` on a stray root file now names `.allowed-root-files` in text output, matching what `--format json` already showed.
- Findings with both fields (e.g. the `L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE` fixture) render the combined layout unchanged.

Plan and exit condition: `plans/text-renderer-shows-expected-without-actual.md`. Explicitly out of scope (tracked separately): `sf verify` `Outcome` serialization and machine-readable `sf explain`/`sf catalog`.