### PR TITLE
test: prove the include_str! registries match their directories

### DIFF
--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -286,3 +286,51 @@ impl Catalog {
         self.rules.get(id)
     }
 }
+
+#[cfg(test)]
+mod completeness {
+    use super::BUILTIN;
+    use std::collections::BTreeSet;
+    use std::path::{Path, PathBuf};
+
+    fn catalog_dir() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("catalog")
+    }
+
+    fn on_disk() -> BTreeSet<String> {
+        walkdir::WalkDir::new(catalog_dir())
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_type().is_file()
+                    && e.path().extension().and_then(|s| s.to_str()) == Some("yaml")
+            })
+            .map(|e| {
+                e.path()
+                    .strip_prefix(catalog_dir())
+                    .expect("walked entry is under catalog_dir")
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect()
+    }
+
+    /// `BUILTIN` is what `sf` ships without a checkout. A `catalog/**/*.yaml`
+    /// with no entry here never reaches a fresh install; an entry with no
+    /// file already failed to compile. Both directions, offenders named.
+    #[test]
+    fn builtin_matches_catalog_dir() {
+        let registered: BTreeSet<String> = BUILTIN.iter().map(|(path, _)| path.to_string()).collect();
+        let disk = on_disk();
+
+        let unregistered: Vec<_> = disk.difference(&registered).collect();
+        let missing: Vec<_> = registered.difference(&disk).collect();
+
+        assert!(
+            unregistered.is_empty() && missing.is_empty(),
+            "catalog::BUILTIN is out of sync with catalog/:\n\
+             files on disk with no BUILTIN entry: {unregistered:?}\n\
+             BUILTIN entries with no file on disk: {missing:?}"
+        );
+    }
+}

--- a/src/interview.rs
+++ b/src/interview.rs
@@ -309,3 +309,50 @@ struct FixtureFile {
     path: String,
     body: String,
 }
+
+#[cfg(test)]
+mod completeness {
+    use super::TEMPLATES;
+    use std::collections::BTreeSet;
+    use std::path::{Path, PathBuf};
+
+    fn templates_dir() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("templates")
+    }
+
+    fn on_disk() -> BTreeSet<String> {
+        std::fs::read_dir(templates_dir())
+            .expect("templates/ exists")
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path().is_file() && e.path().extension().and_then(|s| s.to_str()) == Some("yaml")
+            })
+            .map(|e| {
+                e.path()
+                    .file_stem()
+                    .expect("yaml file has a stem")
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect()
+    }
+
+    /// `TEMPLATES` is the set of parameterised rules an interview can
+    /// instantiate. A `templates/*.yaml` with no entry here is unreachable
+    /// from `sf init`. Both directions, offenders named.
+    #[test]
+    fn templates_matches_templates_dir() {
+        let registered: BTreeSet<String> = TEMPLATES.iter().map(|(name, _)| name.to_string()).collect();
+        let disk = on_disk();
+
+        let unregistered: Vec<_> = disk.difference(&registered).collect();
+        let missing: Vec<_> = registered.difference(&disk).collect();
+
+        assert!(
+            unregistered.is_empty() && missing.is_empty(),
+            "interview::TEMPLATES is out of sync with templates/:\n\
+             files on disk with no TEMPLATES entry: {unregistered:?}\n\
+             TEMPLATES entries with no file on disk: {missing:?}"
+        );
+    }
+}

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -66,3 +66,42 @@ pub fn install(dir: &Path) -> Result<Vec<String>> {
     }
     Ok(written)
 }
+
+#[cfg(test)]
+mod completeness {
+    use super::SKILLS;
+    use std::collections::BTreeSet;
+    use std::path::{Path, PathBuf};
+
+    fn skills_dir() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("skills")
+    }
+
+    fn on_disk() -> BTreeSet<String> {
+        std::fs::read_dir(skills_dir())
+            .expect("skills/ exists")
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir() && e.path().join("SKILL.md").is_file())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect()
+    }
+
+    /// The bug AGENTS.md names: a new `skills/<name>/SKILL.md` with no
+    /// matching entry here ships three of four, silently. Both directions,
+    /// offenders named.
+    #[test]
+    fn skills_matches_skills_dir() {
+        let registered: BTreeSet<String> = SKILLS.iter().map(|(name, _)| name.to_string()).collect();
+        let disk = on_disk();
+
+        let unregistered: Vec<_> = disk.difference(&registered).collect();
+        let missing: Vec<_> = registered.difference(&disk).collect();
+
+        assert!(
+            unregistered.is_empty() && missing.is_empty(),
+            "skills::SKILLS is out of sync with skills/:\n\
+             directories on disk with no SKILLS entry: {unregistered:?}\n\
+             SKILLS entries with no directory on disk: {missing:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Three hand-maintained registries — `catalog::BUILTIN` (32 entries), `skills::SKILLS`, `interview::TEMPLATES` — are `include_str!` lists kept in parallel with directories on disk, with nothing proving they stay in sync. AGENTS.md already documents this failing in practice ("a new skill needs an entry there in the same change, or `sf skills` silently ships three of four"). It is the same class of silent failure L5 exists to catch everywhere else in the method — applied to the tool's own registration machinery.

## Fix

Additive `#[cfg(test)]` modules only — zero changes to production paths. One test per registry walks the directory (`catalog/**/*.yaml`, `skills/*/SKILL.md`, `templates/*.yaml`) and compares sets in both directions, naming every offender in the failure message. No new dependencies (`walkdir` is already one).

## Verification

- `cargo test --release`: 3 passed.
- Mutation proof (the tests are not blind): dropping a stray `catalog/L5/zz-stray.yaml` fails with `files on disk with no BUILTIN entry: ["L5/zz-stray.yaml"]`; a stray `skills/zz-stray/SKILL.md` fails the skills test the same way; an unrelated non-SKILL.md file is correctly ignored.
- `sf verify`: 27/27. `sf check`: unchanged vs baseline (1 finding, frozen by the ratchet).