### PR TITLE
fix(init): report local rules sf fixtures cannot scaffold

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -153,8 +153,10 @@ fn write_fixtures(
     selected: &[&crate::catalog::Rule],
     written: &mut Vec<String>,
 ) -> Result<()> {
+    let mut skipped: Vec<&str> = Vec::new();
     for rule in selected {
         let Some(fixture) = fixtures::for_rule(&rule.id) else {
+            skipped.push(&rule.id);
             continue;
         };
         let base = format!("{FIXTURES_DIR}/{}", rule.id);
@@ -162,6 +164,11 @@ fn write_fixtures(
         for (path, body) in fixture.files {
             write(root, &format!("{base}/{path}"), body, written)?;
         }
+    }
+    for rule_id in skipped {
+        println!(
+            "note: {rule_id} has no built-in fixture; add one by hand at {FIXTURES_DIR}/{rule_id}/"
+        );
     }
     Ok(())
 }


### PR DESCRIPTION
## Problem

The README documents the no-fork extension path: a rule in `.software-factory/rules/` plus a fixture in `.software-factory/mutations/<RULE_ID>/`. But `write_fixtures` resolved fixtures only against the compiled-in table and silently `continue`d past any rule it didn't know — so a user following the documented path exactly got no error, no count, no log from a command whose docstring is "Write the mutation fixtures for every enabled rule", and discovered the gap only when `sf verify` failed later.

## Fix

After the loop, `sf fixtures` (and `sf init`) now print one `note:` per skipped rule, in the existing output style, naming the rule id and the exact path to create by hand:

```
note: LOCAL.NO_FIXTURE_DEMO has no built-in fixture; add one by hand at .software-factory/mutations/LOCAL.NO_FIXTURE_DEMO/
```

Reporting only — no attempt to scaffold a violation for an arbitrary rule, which would be guessing. Built-in fixture writing is unchanged. `src/init.rs` is the only file touched.

## Verification

- Demo (scratch repo, local rule enabled, no compiled fixture): the note above is printed and built-in rules still get their fixtures written.
- `sf verify`: 27/27. `sf check`: unchanged vs baseline (1 finding, frozen by the ratchet).