### PR TITLE
docs: document kind: command as the sanctioned extension path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,12 @@ whose vocabulary does not exist in that language simply omit it — a rule with
 no query for a language does not apply to it, and that is the correct outcome,
 not a gap to paper over.
 
+A rule that can't be decided structurally — its truth only comes out of
+running something, not matching a query — takes `kind: command` instead of a
+grammar. That is the extension point for a check this tool cannot express:
+no fork, no new language, just a rule whose `check.run` exits nonzero when
+it fails. Refused by default; needs `--allow-commands` (see `src/checks/command.rs`).
+
 ## The workflow is hand-maintained
 
 `.github/workflows/software-factory.yml` builds `sf` from source and passes

--- a/README.md
+++ b/README.md
@@ -457,6 +457,18 @@ catalog, which is what lets one rule mean the same thing in four languages.
 cover. **Adding a rule** is a YAML file in `.software-factory/rules/` and a
 fixture under `.software-factory/mutations/<RULE_ID>/`.
 
+**Adding a check** the structural kinds cannot express is `kind: command`: a
+rule whose failure only a subprocess can decide (a schema export, a codegen
+step, a linter this repo already trusts) reports a finding on nonzero exit,
+with no fork required. It needs `sf check --allow-commands` to actually run —
+see [Checks this tool cannot express](#checks-this-tool-cannot-express).
+
+```yaml
+check:
+  kind: command
+  run: "make export-openapi && git diff --exit-code -- contracts/"
+```
+
 Languages today: **Python, TypeScript/TSX, Go, Rust.**
 
 `sf verify` requires every language a rule declares to be shown tripping it,


### PR DESCRIPTION
## Problem

`CheckKind::Command` is the official escape hatch for "a check this tool cannot express" — but that was only written down in a source comment (`src/checks/command.rs`). The README's "Adding a rule" passage covers the structural kinds, so an adopter whose need isn't structural could reasonably conclude a fork of the binary is required. Wrong conclusion, and expensive.

## Fix

One short paragraph in each place an extension-seeker actually reads:

- **README.md**, next to "Adding a rule": names `kind: command` as the answer when a check's truth only comes out of running something, states it needs no fork, shows a minimal YAML example, and notes the `--allow-commands` gate.
- **AGENTS.md**, under "Adding a language": same pointer for contributors, phrased against the grammar path.

Prose only; no code, no generated files touched.

## Verification

- `sf check`: unchanged vs baseline (1 finding, frozen by the ratchet).
- The `--allow-commands` behavior described matches the tool's own finding text ("this rule runs a command, and commands are not enabled").