### PR TITLE
fix(L5): NO_INERT_RULE now sees TextPattern and Complexity rules

### DIFF
--- a/.software-factory/mutations/L5.NO_INERT_RULE/.software-factory/policy.yaml
+++ b/.software-factory/mutations/L5.NO_INERT_RULE/.software-factory/policy.yaml
@@ -11,5 +11,13 @@ rules:
     enabled: true
     options:
       scope: []
+  L1.NO_BLANKET_SUPPRESSION@inert:
+    enabled: true
+    options:
+      scope: ["nonexistent/**"]
+  L1.COMPLEXITY_CEILING@inert:
+    enabled: true
+    options:
+      scope: ["nonexistent/**"]
   L5.NO_INERT_RULE:
     enabled: true

--- a/catalog/L5/no-inert-rule.yaml
+++ b/catalog/L5/no-inert-rule.yaml
@@ -4,16 +4,25 @@ title: An enabled rule must be capable of producing a finding
 severity: high
 statement: >-
   A rule that is switched on must be configured to look at something: a lock
-  rule needs a scope, a toolchain rule needs tools, a gate rule needs a gate.
+  rule needs a scope, a toolchain rule needs tools, a gate rule needs a gate,
+  and a text-pattern or complexity rule needs a scope that actually selects a
+  file it can evaluate.
 why: >-
   `sf verify` proves a rule *can* fire, by running it against a fixture built
   to trip it. It says nothing about whether the rule is pointed at anything in
-  *this* repository. An enabled lock with an empty scope, or a hazard rule with
-  no tools declared, passes every run forever and appears in every report as a
-  rule that found nothing — indistinguishable from a rule that is protecting
-  you. This was not hypothetical: the tool's own scaffolding wrote an empty
-  scope over a critical lock, and nothing noticed until the lock file failed to
-  appear.
+  *this* repository. An enabled lock with an empty scope, or a hazard rule
+  with no tools declared, passes every run forever and appears in every
+  report as a rule that found nothing — indistinguishable from a rule that is
+  protecting you. This was not hypothetical: the tool's own scaffolding wrote
+  an empty scope over a critical lock, and nothing noticed until the lock
+  file failed to appear. The same blindness reaches a text-pattern or
+  complexity rule: a scope glob that matches no file in the repository, or a
+  declared language none of its files ever resolve to, leaves the rule
+  enabled and silent forever. This was also not hypothetical — a repository
+  that declared `languages: [typescript]` while containing zero `.ts` files
+  ran its complexity ceiling and its suppression bans over 365,133 lines and
+  reported nothing, and nothing here noticed until this rule was taught to
+  look.
 fix: >-
   Give the rule something to look at, or switch it off in policy and say why in
   the rules document. Disabled and documented is honest; enabled and inert is

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -262,9 +262,9 @@ For each enabled rule there is a mutation fixture that violates it, and `sf veri
 
 **An enabled rule must be capable of producing a finding**
 
-A rule that is switched on must be configured to look at something: a lock rule needs a scope, a toolchain rule needs tools, a gate rule needs a gate.
+A rule that is switched on must be configured to look at something: a lock rule needs a scope, a toolchain rule needs tools, a gate rule needs a gate, and a text-pattern or complexity rule needs a scope that actually selects a file it can evaluate.
 
-**Why.** `sf verify` proves a rule *can* fire, by running it against a fixture built to trip it. It says nothing about whether the rule is pointed at anything in *this* repository. An enabled lock with an empty scope, or a hazard rule with no tools declared, passes every run forever and appears in every report as a rule that found nothing — indistinguishable from a rule that is protecting you. This was not hypothetical: the tool's own scaffolding wrote an empty scope over a critical lock, and nothing noticed until the lock file failed to appear.
+**Why.** `sf verify` proves a rule *can* fire, by running it against a fixture built to trip it. It says nothing about whether the rule is pointed at anything in *this* repository. An enabled lock with an empty scope, or a hazard rule with no tools declared, passes every run forever and appears in every report as a rule that found nothing — indistinguishable from a rule that is protecting you. This was not hypothetical: the tool's own scaffolding wrote an empty scope over a critical lock, and nothing noticed until the lock file failed to appear. The same blindness reaches a text-pattern or complexity rule: a scope glob that matches no file in the repository, or a declared language none of its files ever resolve to, leaves the rule enabled and silent forever. This was also not hypothetical — a repository that declared `languages: [typescript]` while containing zero `.ts` files ran its complexity ceiling and its suppression bans over 365,133 lines and reported nothing, and nothing here noticed until this rule was taught to look.
 
 **Fix.** Give the rule something to look at, or switch it off in policy and say why in the rules document. Disabled and documented is honest; enabled and inert is a rule that lies about its own coverage.
 

--- a/plans/close-the-inert-rule-blind-spot.md
+++ b/plans/close-the-inert-rule-blind-spot.md
@@ -1,0 +1,90 @@
+# Close the inert-rule blind spot for TextPattern and Complexity
+
+`L5.NO_INERT_RULE` (`inert_rules()` in `src/checks/cadence.rs`) checked five of
+the eleven check kinds: an enabled lock with an empty scope, a command rule
+with no `run`, a toolchain rule with no tools, and a shape or nested rule with
+no query for a declared language. It never looked at `TextPattern` or
+`Complexity`, which are exactly the kinds L1 is built from.
+
+This was not theoretical. Measured on `~/Sites/pp-team/postpilot` (365,133
+lines of Ruby, 4,683 `.rb` files, zero `.ts .tsx .jsx .py .go .rs`) with
+`languages: [typescript]` declared: `L1.COMPLEXITY_CEILING`,
+`L1.NO_BLANKET_SUPPRESSION` and `L1.NO_UNTYPED_ESCAPE_HATCH` all reported
+nothing across the whole repository, and `L5.NO_INERT_RULE` declared the
+policy sound. A rule that passes every run forever and shows up in every
+report as "found nothing" is indistinguishable from a rule that is protecting
+you — which is the precise failure this rule exists to catch, and it was
+blind to its own two most common kinds.
+
+## The decision that mattered: what "inert" means for a text-pattern rule
+
+Two candidate tests were considered for `TextPattern`:
+
+1. **The scope glob matches zero files in the repository.**
+2. **The scope names no extension belonging to a language the project
+   declares.**
+
+They differ, and the difference is the whole point. `L1.NO_BLANKET_SUPPRESSION`
+and `L1.NO_UNTYPED_ESCAPE_HATCH` both default their scope to
+`**/*.py, **/*.ts, **/*.tsx, **/*.go, **/*.rs` — a fixed set of extensions,
+independent of what the repository's policy declares. Test 2 would read that
+scope as "covers typescript" the moment a repository declares
+`languages: [typescript]`, and say the rule is fine — exactly the state
+postpilot was in, and exactly the state that was silently wrong. Test 1 asks
+the only question that is actually true or false in this repository: did the
+glob select a single file. Chosen: **test 1**, implemented as
+`scan::select(ctx.files, &options.scope, &options.exclude)?.is_empty()` — the
+same selection the check itself runs, so the inertness test can never disagree
+with the check about what it can see.
+
+## Complexity
+
+`checks::complexity::run` silently skips a file for two independent reasons:
+`Lang::from_path` cannot classify the extension, or the classified language is
+not in `ctx.policy.project.languages`. Either one alone leaves the rule
+inert if it holds for every file the scope selects. `any_parseable_declared_file`
+in `cadence.rs` mirrors both skip conditions exactly and asks whether any
+selected file survives both — the same combined question `complexity::run`
+answers per file, asked once in aggregate.
+
+## False-positive risk
+
+The failure mode this change most easily produces is flagging a rule that is
+genuinely fine — silently loosening a check to "fix" a false alarm is exactly
+what `L2.POLICY_ONLY_TIGHTENS` and this repository's own method exist to
+catch, so the test had to be checked against a codebase where the affected
+rules are real. `software-factory` itself declares `languages: [rust]` and has
+its own `.rs` files under the default text-pattern scopes, so
+`L1.NO_BLANKET_SUPPRESSION`, `L1.NO_UNTYPED_ESCAPE_HATCH` and
+`L1.COMPLEXITY_CEILING` all select real files here — `sf check` on this
+repository stays clean under the new detection.
+
+## Evidence
+
+- `sf verify` fires `L5.NO_INERT_RULE` on the extended fixture
+  (`.software-factory/mutations/L5.NO_INERT_RULE/`), which now enables one
+  inert instance of each of the three kinds: `L2.GENERATED_FILES_ARE_LOCKED`
+  (empty scope, the pre-existing case), `L1.NO_BLANKET_SUPPRESSION@inert` and
+  `L1.COMPLEXITY_CEILING@inert` (both scoped at `nonexistent/**`, the new
+  cases) — three separate findings under one rule id.
+- `sf check` on `software-factory` itself stays clean.
+- A temporary policy pointed at a read-only symlink to `~/Sites/pp-team/postpilot`
+  with `languages: [typescript]` and the L1 layer enabled reproduces the
+  original blindness on the binary built before this change (only the
+  pre-existing `L1.SKIPPED_TESTS_STATE_A_REASON` finding — the Shape/Nested
+  case already covered) and shows the binary built after this change naming
+  all three previously-silent rules by id and reason.
+
+## Non-goals
+
+This does not touch `Lang::from_path`, `Lang::from_name`, any tree-sitter
+grammar, or the `L6.*` toolchain lists — a repository declaring a language
+`sf` cannot parse at all is a different, already-tracked gap
+(`plans/expand-language-adapters.md`). This plan is only about the guardrail
+noticing that gap in its own report, not about closing it.
+
+**Exit condition:** `sf verify` shows `L5.NO_INERT_RULE` firing on a fixture
+that is inert only through the `TextPattern` or `Complexity` path — proven —
+and running the built `sf` against a real repository whose declared language
+matches none of its files names the blind `L1.*` rules instead of staying
+silent, proven by the postpilot reproduction above.

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -20,6 +20,8 @@ precondition exists. Park it in the second table rather than deleting it.
 
 | 6 | [Rules activate on the version of the dependency they are about](rules-activate-by-dependency-version.md) | Changing a dependency's pin in the manifest makes `sf check` fail by naming every rule whose `when` no longer matches, instead of leaving them enabled and inert. |
 
+| 7 | [Close the inert-rule blind spot for TextPattern and Complexity](close-the-inert-rule-blind-spot.md) | `sf verify` fires `L5.NO_INERT_RULE` on a fixture inert only through the `TextPattern` or `Complexity` path, and the built binary run against a real repository whose declared language matches none of its files names the blind `L1.*` rules instead of staying silent. |
+
 ## Parked
 
 | Work | Waiting on |

--- a/src/checks/cadence.rs
+++ b/src/checks/cadence.rs
@@ -7,6 +7,7 @@
 use super::Ctx;
 use crate::catalog::{CadenceMode, CheckKind, Rule};
 use crate::finding::Finding;
+use crate::lang::Lang;
 use crate::policy::{FIXTURES_DIR, Options};
 use crate::scan;
 use anyhow::Result;
@@ -44,26 +45,43 @@ fn inert_rules(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
         };
         let (id, candidate) = (&instance, &super::as_instance(candidate, &instance));
         let options = super::options_for(candidate, ctx.policy)?;
-        let reason = match &candidate.check {
-            CheckKind::Lock if options.scope.is_empty() => "no scope: it locks nothing",
+        let reason: Option<&str> = match &candidate.check {
+            CheckKind::Lock if options.scope.is_empty() => Some("no scope: it locks nothing"),
             CheckKind::Command if options.run.is_none() => {
-                "no command set: there is nothing for it to run"
+                Some("no command set: there is nothing for it to run")
             }
             CheckKind::Toolchain if options.tools.is_empty() => {
-                "no tools declared: it can never find one missing"
+                Some("no tools declared: it can never find one missing")
             }
             CheckKind::Shape { languages }
                 if !covers_a_declared_language(languages.keys(), ctx) =>
             {
-                "no query for any language this repository declares"
+                Some("no query for any language this repository declares")
             }
             CheckKind::Nested { languages }
                 if !covers_a_declared_language(languages.keys(), ctx) =>
             {
-                "no query for any language this repository declares"
+                Some("no query for any language this repository declares")
             }
-            _ => continue,
+            CheckKind::TextPattern => {
+                if scan::select(ctx.files, &options.scope, &options.exclude)?.is_empty() {
+                    Some("scope matches no file in this repository: it can never see a line to check")
+                } else {
+                    None
+                }
+            }
+            CheckKind::Complexity => {
+                if !any_parseable_declared_file(ctx, &options)? {
+                    Some(
+                        "no file in scope parses into a language this repository declares: the ceiling can never be evaluated",
+                    )
+                } else {
+                    None
+                }
+            }
+            _ => None,
         };
+        let Some(reason) = reason else { continue };
         findings.push(
             Finding::new(
                 &rule.id,
@@ -76,6 +94,20 @@ fn inert_rules(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
         );
     }
     Ok(findings)
+}
+
+/// Whether at least one file the rule's scope selects has an extension this
+/// tool can parse into a language the project actually declares. Mirrors
+/// `checks::complexity::run`'s own skip conditions exactly — both the
+/// language-classification skip and the declared-language skip, since either
+/// one alone leaves the ceiling silently inert.
+fn any_parseable_declared_file(ctx: &Ctx, options: &Options) -> Result<bool> {
+    let selected = scan::select(ctx.files, &options.scope, &options.exclude)?;
+    Ok(selected.iter().any(|f| {
+        Lang::from_path(&f.abs).is_some_and(|lang| {
+            ctx.policy.project.languages.iter().any(|declared| declared == lang.name())
+        })
+    }))
 }
 
 /// Markdown link targets: `[text](target)` and reference definitions.

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -381,9 +381,12 @@ pub const FIXTURES: &[Fixture] = &[
     Fixture {
         rule: "L5.NO_INERT_RULE",
         policy_extra: "",
-        // A lock switched on over nothing: it passes every run and reads in a
-        // report exactly like a lock that is protecting something.
-        extra_rules: "  L2.GENERATED_FILES_ARE_LOCKED:\n    enabled: true\n    options:\n      scope: []\n",
+        // Three ways to be inert, one per newly/previously covered kind: a
+        // lock switched on over nothing, a text-pattern rule scoped at a path
+        // nothing in the mini-repo matches, and a complexity ceiling scoped
+        // the same way. Each passes every run and reads in a report exactly
+        // like a rule that is protecting you.
+        extra_rules: "  L2.GENERATED_FILES_ARE_LOCKED:\n    enabled: true\n    options:\n      scope: []\n  L1.NO_BLANKET_SUPPRESSION@inert:\n    enabled: true\n    options:\n      scope: [\"nonexistent/**\"]\n  L1.COMPLEXITY_CEILING@inert:\n    enabled: true\n    options:\n      scope: [\"nonexistent/**\"]\n",
         files: &[("src/app.py", "print('a repository with a lock that locks nothing')\n")],
     },
 ];


### PR DESCRIPTION
## Problem

`inert_rules()` (`src/checks/cadence.rs:38-78` on `upstream/main` at `76ec836`) is `L5.NO_INERT_RULE`'s own self-check: an enabled rule configured so it can never produce a finding. It inspected five of the eleven check kinds — Lock, Command, Toolchain, Shape and Nested — and never TextPattern or Complexity, which is what `L1.NO_BLANKET_SUPPRESSION`, `L1.NO_UNTYPED_ESCAPE_HATCH` and `L1.COMPLEXITY_CEILING` are built from.

This is the tool's own self-check having exactly the hole its own `why` prose warns about: "An enabled lock with an empty scope... passes every run forever and appears in every report as a rule that found nothing — indistinguishable from a rule that is protecting you." That sentence turns out to also describe TextPattern and Complexity, and nothing checked for it there.

Measured on `~/Sites/pp-team/postpilot` (4,683 `.rb` files, 365,133 lines, zero `.ts`/`.tsx`/`.jsx`/`.py`/`.go`/`.rs` files — postpilot runs RSpec/standardrb/erb_lint, no brakeman/gitleaks/zizmor): a policy declaring `languages: [typescript]` with the L1 layer enabled ran `L1.COMPLEXITY_CEILING`, `L1.NO_BLANKET_SUPPRESSION` and `L1.NO_UNTYPED_ESCAPE_HATCH` against the whole repository and reported nothing from any of them, and `L5.NO_INERT_RULE` said the policy was sound.

## Fix

Extended `inert_rules()` to cover both kinds:

- **TextPattern** is inert when its scope glob selects zero files in the repository — `scan::select(ctx.files, &options.scope, &options.exclude)?.is_empty()`, the exact same selection `text_pattern::run` itself uses. Chosen deliberately over "scope names no extension belonging to a declared language": `L1.NO_BLANKET_SUPPRESSION` and `L1.NO_UNTYPED_ESCAPE_HATCH` both default their scope to `**/*.py, **/*.ts, **/*.tsx, **/*.go, **/*.rs`, a fixed extension list independent of what a policy declares. The extension-matching test would call postpilot's `languages: [typescript]` policy fine — `**/*.ts` does name typescript — even though zero files match it, which is exactly the false-negative state postpilot was actually in.
- **Complexity** is inert when no file its scope selects survives both skip conditions `complexity::run` already applies per file: classifiable by `Lang::from_path`, and that language present in `ctx.policy.project.languages`.

Reasoning written up in `plans/close-the-inert-rule-blind-spot.md`, including the false-positive risk this change is mainly guarding against.

## Verification

- `cargo build --release` finishes clean.
- `./target/release/sf verify` — `27/27 enabled rules proven to fire`. The extended `L5.NO_INERT_RULE` fixture (`.software-factory/mutations/L5.NO_INERT_RULE/`) now enables one inert instance of each of three kinds — the pre-existing empty-lock case plus a new `L1.NO_BLANKET_SUPPRESSION@inert` and `L1.COMPLEXITY_CEILING@inert`, both scoped at `nonexistent/**` — and `sf verify` shows all three as separate findings under the one rule id.
- `./target/release/sf check --allow-commands` on this repository — `✓ 27 rules, no findings (1 frozen by the ratchet)`. software-factory declares `languages: [rust]` and its text-pattern/complexity scopes include `**/*.rs`, which this repository has, so nothing here is inert and the new detection introduces no false positive.
- Reproduction: a temporary policy (`.software-factory/policy.yaml` pointed at a read-only symlink to `~/Sites/pp-team/postpilot`, never modified) declaring `languages: [typescript]` with the L1 layer plus `L5.NO_INERT_RULE` enabled. The binary built from `upstream/main` at `76ec836` reports only the pre-existing Shape/Nested finding (`L1.SKIPPED_TESTS_STATE_A_REASON` — no Ruby query). The binary built from this branch additionally names all three previously-silent rules:
  ```
  .software-factory/policy.yaml — L1.COMPLEXITY_CEILING is enabled but cannot produce a finding — no file in scope parses into a language this repository declares: the ceiling can never be evaluated
  .software-factory/policy.yaml — L1.NO_BLANKET_SUPPRESSION is enabled but cannot produce a finding — scope matches no file in this repository: it can never see a line to check
  .software-factory/policy.yaml — L1.NO_UNTYPED_ESCAPE_HATCH is enabled but cannot produce a finding — scope matches no file in this repository: it can never see a line to check
  ```

Plan and exit condition: `plans/close-the-inert-rule-blind-spot.md`, row 6 of `plans/next-steps.md`. Explicitly out of scope: `Lang::from_path`/`Lang::from_name` and any tree-sitter grammar (postpilot's Ruby files staying unparseable is a separate, already-tracked gap — `plans/expand-language-adapters.md`), and the `L6.*` toolchain lists. This PR is only about the guardrail noticing that gap in its own report, not about closing it.
