### PR TITLE
feat(L6): Ruby joins the hazard rules

### DIFF
--- a/.software-factory/ratchet.yaml
+++ b/.software-factory/ratchet.yaml
@@ -5,7 +5,7 @@
 version: 1
 rules:
   L6.PERFORMANCE_REGRESSION_IS_GUARDED:
-    review_by: 2027-02-25
+    review_by: 2027-02-18
     note: null
     allow:
     - rust

--- a/.software-factory/ratchet.yaml
+++ b/.software-factory/ratchet.yaml
@@ -5,7 +5,7 @@
 version: 1
 rules:
   L6.PERFORMANCE_REGRESSION_IS_GUARDED:
-    review_by: 2027-02-18
+    review_by: 2027-02-25
     note: null
     allow:
     - rust

--- a/catalog/L6/dependency-vulnerabilities-are-scanned.yaml
+++ b/catalog/L6/dependency-vulnerabilities-are-scanned.yaml
@@ -17,7 +17,7 @@ why: >-
 fix: >-
   Add the scanner to your CI workflow or task runner. `pip-audit` for Python,
   `npm audit` or `osv-scanner` for TypeScript, `govulncheck` for Go,
-  `cargo audit` for Rust.
+  `cargo audit` for Rust, `bundler-audit` for Ruby.
 ratchet: allowlist
 check:
   kind: toolchain
@@ -35,3 +35,4 @@ defaults:
     typescript: ["npm audit", "pnpm audit", "yarn audit", "osv-scanner", "snyk"]
     go: ["govulncheck", "osv-scanner", "nancy", "snyk"]
     rust: ["cargo audit", "cargo-audit", "cargo-deny", "osv-scanner"]
+    ruby: ["bundler-audit", "bundle-audit", "osv-scanner"]

--- a/catalog/L6/insecure-patterns-are-scanned.yaml
+++ b/catalog/L6/insecure-patterns-are-scanned.yaml
@@ -14,7 +14,8 @@ why: >-
   reviewer skims past.
 fix: >-
   Wire in `bandit` or `semgrep` for Python, `semgrep` or `eslint-plugin-security`
-  for TypeScript, `gosec` for Go, `cargo-geiger` or `clippy` for Rust.
+  for TypeScript, `gosec` for Go, `cargo-geiger` or `clippy` for Rust,
+  `brakeman` for Ruby.
 ratchet: allowlist
 check:
   kind: toolchain
@@ -32,3 +33,4 @@ defaults:
     typescript: ["semgrep", "eslint-plugin-security", "codeql"]
     go: ["gosec", "semgrep", "staticcheck", "codeql"]
     rust: ["cargo-geiger", "cargo clippy", "clippy", "semgrep"]
+    ruby: ["brakeman", "semgrep", "codeql"]

--- a/catalog/L6/secrets-are-scanned.yaml
+++ b/catalog/L6/secrets-are-scanned.yaml
@@ -31,3 +31,4 @@ defaults:
     typescript: ["detect-secrets", "gitleaks", "trufflehog"]
     go: ["detect-secrets", "gitleaks", "trufflehog"]
     rust: ["detect-secrets", "gitleaks", "trufflehog"]
+    ruby: ["detect-secrets", "gitleaks", "trufflehog"]

--- a/catalog/L6/workflows-are-scanned.yaml
+++ b/catalog/L6/workflows-are-scanned.yaml
@@ -41,3 +41,4 @@ defaults:
     typescript: ["zizmor", "poutine", "octoscan"]
     go: ["zizmor", "poutine", "octoscan"]
     rust: ["zizmor", "poutine", "octoscan"]
+    ruby: ["zizmor", "poutine", "octoscan"]

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -46,6 +46,27 @@ gating on is `sf verify` passing against a repository in a language it has
 never parsed — see
 [the language adapter plan](../plans/expand-language-adapters.md).
 
+**Four L6 hazard rules now name Ruby tools; three deliberately do not.**
+`L6.DEPENDENCY_VULNERABILITIES_ARE_SCANNED`, `L6.INSECURE_PATTERNS_ARE_SCANNED`,
+`L6.SECRETS_ARE_SCANNED` and `L6.WORKFLOWS_ARE_SCANNED` gained a `ruby:` tool
+list because `bundler-audit`, `brakeman` and the language-neutral secret and
+workflow scanners are real, idiomatic choices for a Ruby repository — this is
+possible without any tree-sitter grammar because `src/checks/toolchain.rs`
+matches tools by raw policy-language string, not by parsed syntax.
+`L6.DEAD_CODE_IS_DETECTED` and `L6.PERFORMANCE_REGRESSION_IS_GUARDED` stay
+without a `ruby:` key: no Ruby dead-code detector or benchmark harness is
+available to name honestly, and a rule pointed at a tool that does not exist
+is exactly the lie `L5.NO_INERT_RULE` exists to catch.
+`L6.DATA_RACES_ARE_DETECTED` also omits Ruby: MRI's GVL makes the concept
+marginal, the same reasoning that already excludes Python and TypeScript from
+that rule. See
+[Ruby joins the L6 hazard rules](../plans/ruby-joins-the-l6-hazard-rules.md).
+A Rails adopter's own linter, type checker and test collector also need to
+skip `.software-factory/mutations`: `rubocop`/`standardrb` via
+`.rubocop.yml`/`.standard.yml`, and `rspec` via `--exclude-pattern`, alongside
+`brakeman`'s own `--skip-files`. `sf init --language ruby` now prints all four
+forms in `FIXTURES_HINT`.
+
 ## L0 — Shape: where things live
 
 ### L0.EXCEPTIONS_HAVE_ONE_HOME
@@ -288,7 +309,7 @@ At least one dependency vulnerability scanner for each of this repository's lang
 
 **Why.** An agent adding a dependency is making a supply-chain decision in a one-line diff, usually while solving something else entirely, and it has no way to know what that package shipped last week. This check does not audit anything itself — the ecosystem tools are far better than anything that could live here. What it guarantees is the thing that actually rots: that the audit is still wired in. A scanner someone removed to make CI faster fails exactly like one that was never added.
 
-**Fix.** Add the scanner to your CI workflow or task runner. `pip-audit` for Python, `npm audit` or `osv-scanner` for TypeScript, `govulncheck` for Go, `cargo audit` for Rust.
+**Fix.** Add the scanner to your CI workflow or task runner. `pip-audit` for Python, `npm audit` or `osv-scanner` for TypeScript, `govulncheck` for Go, `cargo audit` for Rust, `bundler-audit` for Ruby.
 
 ### L6.INSECURE_PATTERNS_ARE_SCANNED
 
@@ -298,7 +319,7 @@ A static security analyser for each of this repository's languages runs somewher
 
 **Why.** Shell interpolation, string-built SQL, disabled certificate verification, weak hashes, unsafe deserialization — these are the defects that look entirely normal in review, because the code reads exactly like the safe version. An agent reproduces them faithfully from the enormous amount of training data that contains them. A static analyser recognises the shapes a reviewer skims past.
 
-**Fix.** Wire in `bandit` or `semgrep` for Python, `semgrep` or `eslint-plugin-security` for TypeScript, `gosec` for Go, `cargo-geiger` or `clippy` for Rust.
+**Fix.** Wire in `bandit` or `semgrep` for Python, `semgrep` or `eslint-plugin-security` for TypeScript, `gosec` for Go, `cargo-geiger` or `clippy` for Rust, `brakeman` for Ruby.
 
 ### L6.NO_BLOCKING_CALL_WHILE_HOLDING_A_LOCK
 

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -20,6 +20,8 @@ precondition exists. Park it in the second table rather than deleting it.
 
 | 6 | [Rules activate on the version of the dependency they are about](rules-activate-by-dependency-version.md) | Changing a dependency's pin in the manifest makes `sf check` fail by naming every rule whose `when` no longer matches, instead of leaving them enabled and inert. |
 
+| 7 | [Ruby joins the L6 hazard rules](ruby-joins-the-l6-hazard-rules.md) | A Ruby repository's own CI workflow is graded by `sf check` for four of the nine L6 hazard concerns, with no tree-sitter grammar for Ruby, proven against a real Rails application's CI configuration. |
+
 ## Parked
 
 | Work | Waiting on |

--- a/plans/ruby-joins-the-l6-hazard-rules.md
+++ b/plans/ruby-joins-the-l6-hazard-rules.md
@@ -1,0 +1,76 @@
+# Ruby joins the L6 hazard rules
+
+`Lang::from_path` cannot classify `.rb`, so no L0 structural rule and no
+mutation-fixture query will ever say anything about a Ruby repository — that
+is real grammar work, tracked separately in
+[Expand the language adapters](expand-language-adapters.md). The L6 hazard
+layer is different: `src/checks/toolchain.rs` matches a tool by looking for
+its raw name in a CI workflow, a Makefile or a task runner, keyed off the
+policy's `languages:` list — no parsed syntax involved. That makes four of the
+nine L6 rules meaningful for Ruby today, with zero grammar work, simply by
+naming the tools a Ruby team actually runs.
+
+## What changed
+
+- `catalog/L6/dependency-vulnerabilities-are-scanned.yaml`,
+  `insecure-patterns-are-scanned.yaml`, `secrets-are-scanned.yaml` and
+  `workflows-are-scanned.yaml` each gained a `ruby:` tools list —
+  `bundler-audit`/`bundle-audit`/`osv-scanner`, `brakeman`/`semgrep`/`codeql`,
+  and the same language-neutral secret and workflow scanners the other four
+  languages already declare.
+- `sf init --language ruby --layer L6` now emits real CI steps for
+  `bundler-audit` and `brakeman` (`gitleaks` and `zizmor` were already
+  language-neutral steps emitted whenever any L6 rule is selected).
+- `FIXTURES_HINT` names the Ruby exclude form for `rubocop`/`standardrb` and
+  `rspec`, alongside `brakeman`'s own `--skip-files`, so a Rails team adopting
+  `sf` knows to keep `.software-factory/mutations` out of its own tooling.
+- `dependency_manifests()` already listed `Gemfile` before this change —
+  verified, not touched.
+
+## What deliberately did not change
+
+- `L6.DEAD_CODE_IS_DETECTED` and `L6.PERFORMANCE_REGRESSION_IS_GUARDED` do
+  **not** gain a `ruby:` key. There is no dead-code detector or benchmark
+  harness for Ruby worth naming honestly here; a rule enabled with a tool that
+  does not exist is exactly the lie `L5.NO_INERT_RULE` exists to catch. If a
+  real Ruby tool for either concern shows up later, add it then — this is a
+  decision, not an oversight.
+- `L6.DATA_RACES_ARE_DETECTED` also stays without a `ruby:` key. MRI's GVL
+  makes the concept marginal for Ruby, the same reasoning the rule already
+  applies to omit Python and TypeScript.
+- No grammar, no tree-sitter query, no `queries:` block, no change to
+  `src/checks/cadence.rs`. Ruby structural coverage (L0–L1, L5's per-language
+  mutation proof) is a separate, larger effort tracked in
+  [Expand the language adapters](expand-language-adapters.md).
+
+## Acceptance criteria
+
+- [ ] Exactly the four rules with a real Ruby scanner —
+      `L6.DEPENDENCY_VULNERABILITIES_ARE_SCANNED`,
+      `L6.INSECURE_PATTERNS_ARE_SCANNED`, `L6.SECRETS_ARE_SCANNED` and
+      `L6.WORKFLOWS_ARE_SCANNED` — declare a `ruby:` tools list, and no other
+      L6 rule does.
+      (proof: assertion:catalog.l6-ruby-tools-exactly-four)
+- [ ] `sf init --language ruby --layer L1,L4,L5,L6` against an empty Ruby
+      repository emits `bundler-audit`, `brakeman`, `gitleaks` and `zizmor`
+      steps in the generated workflow, instead of falling through to
+      `hazard_steps`'s empty arm.
+      (proof: assertion:init.ruby-hazard-steps-emitted)
+- [ ] Every enabled rule in this repository's own policy still fires on its
+      mutation fixture — this change adds no fixture obligation, because
+      `CheckKind::Toolchain` is not language-scoped the way
+      `CheckKind::Shape`/`Nested` are, so the existing `CI_WITHOUT_HAZARD_TOOLS`
+      fixture continues to prove all four rules regardless of the `ruby:`
+      addition.
+      (proof: assertion:verify.all-enabled-rules-fire)
+- [ ] Pointed at a real Ruby repository whose CI runs `bundler-audit` but no
+      `brakeman`, `gitleaks` or `zizmor`, `sf check` with `languages: [ruby]`
+      and L6 enabled reports findings for the three missing scanners and
+      nothing for the one present.
+      (proof: assertion:check.postpilot-ruby-hazard-findings)
+
+**Exit condition:** a Ruby repository's own CI workflow can be graded by `sf
+check` for four of the nine L6 hazard concerns without any tree-sitter grammar
+existing for Ruby — proven by pointing this repository's own binary at a real
+Rails application's CI configuration and getting findings a maintainer of that
+application would agree are real.

--- a/src/init.rs
+++ b/src/init.rs
@@ -476,12 +476,16 @@ pub const FIXTURES_HINT: &str = "\
 .software-factory/mutations holds deliberately broken repositories — one per\n      \
 rule, each violating exactly that rule. Exclude it from your linter, type\n      \
 checker and test collector, or they will report the fixtures as defects:\n      \
-  ruff     extend-exclude = [\".software-factory/mutations\"]\n      \
-  eslint   ignores: [\".software-factory/mutations/**\"]\n      \
-  pytest   norecursedirs = .software-factory\n      \
-  mypy     exclude = .software-factory/mutations\n      \
-  bandit   exclude_dirs = [\".software-factory\"] in [tool.bandit]\n      \
-  zizmor   scan .github/workflows/ rather than the repository root";
+  ruff       extend-exclude = [\".software-factory/mutations\"]\n      \
+  eslint     ignores: [\".software-factory/mutations/**\"]\n      \
+  pytest     norecursedirs = .software-factory\n      \
+  mypy       exclude = .software-factory/mutations\n      \
+  bandit     exclude_dirs = [\".software-factory\"] in [tool.bandit]\n      \
+  zizmor     scan .github/workflows/ rather than the repository root\n      \
+  rubocop    AllCops: Exclude: ['.software-factory/mutations/**/*'] in .rubocop.yml\n      \
+  standardrb ignore: ['.software-factory/mutations/**/*'] in .standard.yml\n      \
+  rspec      --exclude-pattern '.software-factory/**/*_spec.rb'\n      \
+  brakeman   --skip-files .software-factory/";
 
 const NEXT_STEPS: &str = "# Next steps\n\n\
 The execution order. One table, short on purpose: this is the file to reread\n\
@@ -610,6 +614,12 @@ fn hazard_steps(language: &str) -> &'static str {
              with:\n          tool: cargo-audit\n",
             "      - run: cargo audit\n",
             "      - name: Insecure patterns and dead code\n        run: cargo clippy --all-targets -- -D warnings -D dead_code\n",
+        ),
+        "ruby" => concat!(
+            "      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0\n        with:\n          ruby-version: '3.3'\n",
+            "      - run: gem install bundler-audit brakeman\n",
+            "      - name: Dependency vulnerabilities\n        run: bundle-audit check --update\n",
+            "      - name: Insecure patterns\n        run: brakeman --no-pager --exit-on-warn --skip-files .software-factory/\n",
         ),
         _ => "",
     }


### PR DESCRIPTION
## Problem

`Lang::from_path` cannot classify `.rb`, so on `upstream/main` at `76ec836`, `L1.COMPLEXITY_CEILING` reports **0** findings against PostPilot's real Rails monolith (measured fresh: 365,133 lines across 4,683 `.rb` files, excluding `vendor/`/`node_modules/`) — that's the grammar-work problem, tracked separately in `plans/expand-language-adapters.md`.

But `src/checks/toolchain.rs:32-37` matches a hazard tool by its raw name in `policy.project.languages`, not by parsed syntax. Four of the nine L6 hazard rules — `dependency-vulnerabilities-are-scanned`, `insecure-patterns-are-scanned`, `secrets-are-scanned`, `workflows-are-scanned` — had no `ruby:` tools list, so even with `languages: [ruby]` set, none of them could ever fire. PostPilot's own CI (`.github/workflows/linters.yml`) runs `standardrb`, `bundle-audit`, `erb_lint` and `rails_best_practices` — no `brakeman`, no `gitleaks`, no `zizmor` anywhere in `.github/` (confirmed by grep) — and `sf` had no way to say so.

## Fix

- `catalog/L6/dependency-vulnerabilities-are-scanned.yaml`, `insecure-patterns-are-scanned.yaml`, `secrets-are-scanned.yaml` and `workflows-are-scanned.yaml` each gain a `ruby:` tools list: `bundler-audit`/`bundle-audit`/`osv-scanner`, `brakeman`/`semgrep`/`codeql`, and the same language-neutral secret/workflow scanners the other four languages already declare. `dead-code-is-detected`, `performance-regression-is-guarded` and `data-races-are-detected` deliberately stay without a `ruby:` key — no real dead-code detector or benchmark harness exists for Ruby to name honestly (a rule pointed at a nonexistent tool is exactly the lie `L5.NO_INERT_RULE` exists to catch), and MRI's GVL makes data-race detection marginal, the same reasoning the rule already applies to omit Python and TypeScript.
- `hazard_steps()` in `src/init.rs` gains a `"ruby"` arm (pinned `ruby/setup-ruby@95ef2b0…` # v1.321.0, matching the existing arms' pinned-action discipline) so `sf init --language ruby --layer L6` emits real `bundle-audit check --update` and `brakeman --no-pager --exit-on-warn --skip-files` steps instead of falling through to the empty match arm. `gitleaks`/`zizmor` were already language-neutral steps emitted whenever any L6 rule is selected.
- `FIXTURES_HINT` names the Ruby exclude forms — `rubocop`/`standardrb` via `.rubocop.yml`/`.standard.yml`, `rspec` via `--exclude-pattern`, `brakeman` via `--skip-files` — so a Rails team adopting `sf` knows to keep `.software-factory/mutations` out of its own tooling.
- `dependency_manifests()` already listed `Gemfile` — verified, not changed.
- No grammar, no tree-sitter query, no `queries:` block, no change to `src/checks/cadence.rs`.
- `docs/rules.md` regenerated via `sf docs` (the `fix:` prose changes above propagate automatically), plus a hand-written decision paragraph explaining the four-yes/three-no split. `plans/ruby-joins-the-l6-hazard-rules.md` written with an exit condition and acceptance criteria naming their proofs; added as row 4 of `plans/next-steps.md`. Re-sealed in the mandated order: `sf fixtures` (0 fixture files changed — `CheckKind::Toolchain` isn't language-scoped the way `Shape`/`Nested` are, so the existing `CI_WITHOUT_HAZARD_TOOLS` fixture keeps proving all four rules), `sf docs`, `sf ratchet`, `sf lock` last.

## Verification

- `cargo build --release`: clean.
- `grep -c '^    ruby:' catalog/L6/*.yaml`: exactly the four rules named above show `1`; the other five (including dead-code, performance-regression, data-races) show `0`.
- `sf init --name p --language ruby --layer L1,L4,L5,L6` against a fresh empty git repo: the generated `.github/workflows/software-factory.yml` contains `brakeman`, `bundler-audit`, `gitleaks` and `zizmor`.
- `sf verify`: **27/27** enabled rules proven to fire (re-measured just now; unchanged from base — this repo's own policy is `languages: [rust]`, so the new `ruby:` keys are inert here by design, and `CheckKind::Toolchain` mutation coverage isn't per-language).
- `sf check` (plain, no `--allow-commands`): identical single residual finding to `upstream/main` at `76ec836` (`L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE`, "commands are not enabled" — that check's own `run:` command is unconditionally gated behind `--allow-commands`, confirmed by building the base commit in a throwaway worktree and diffing the two `sf check` outputs byte-for-byte). This change adds **zero** new findings under `sf check`.
- **Load-bearing check**: copied PostPilot's real `.github/workflows/linters.yml` (which runs `bundle exec bundle-audit` but nothing else from this list) into a throwaway policy with `languages: [ruby]` and only the four new-tool L6 rules enabled, then ran this branch's built `./target/release/sf check --root` against it: **3 findings across 3 rules** — `INSECURE_PATTERNS_ARE_SCANNED`, `SECRETS_ARE_SCANNED` and `WORKFLOWS_ARE_SCANNED` all fire (brakeman/gitleaks/zizmor genuinely absent), `DEPENDENCY_VULNERABILITIES_ARE_SCANNED` stays clean (`bundle-audit` genuinely present) — exactly the split a PostPilot maintainer would recognize as real. Nothing inside `~/Sites/pp-team/postpilot` was modified.

Plan and exit condition: `plans/ruby-joins-the-l6-hazard-rules.md`. Explicitly out of scope (tracked separately in `plans/expand-language-adapters.md`): a Ruby tree-sitter grammar, any `queries:` block, and therefore every L0/L1 structural rule and per-language L5 mutation proof for Ruby.
