### PR TITLE
docs: a contributors list nobody has to remember to update

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,6 +816,13 @@ each as a written decision in [`docs/rules.md`](docs/rules.md) — because
 
 See [`docs/method.md`](docs/method.md) for the reasoning behind the layering.
 
+## Contributors
+
+The list below is the GitHub contributors graph, rendered. It updates itself as
+people land commits, so nobody has to remember to edit it.
+
+[![Contributors](https://contrib.rocks/image?repo=nicolasmelo1/software-factory)](https://github.com/nicolasmelo1/software-factory/graphs/contributors)
+
 ## License
 
 MIT.

--- a/README.md
+++ b/README.md
@@ -818,9 +818,6 @@ See [`docs/method.md`](docs/method.md) for the reasoning behind the layering.
 
 ## Contributors
 
-The list below is the GitHub contributors graph, rendered. It updates itself as
-people land commits, so nobody has to remember to edit it.
-
 [![Contributors](https://contrib.rocks/image?repo=nicolasmelo1/software-factory)](https://github.com/nicolasmelo1/software-factory/graphs/contributors)
 
 ## License


### PR DESCRIPTION
Adds a `## Contributors` section near the end of the README, just above `## License`.

It renders the GitHub contributors graph via contrib.rocks, so it updates itself as people land commits. No workflow, no token, no `contents: write`.

I considered a scheduled job that reads `/repos/.../contributors` and rewrites a marked block in the README. It gives you names and links instead of avatars, but it costs a job with write access and an automatic commit on `main`. Given `L6.WORKFLOWS_ARE_SCANNED` argues the workflow file is the highest-privilege code in the repo, that trade looked wrong for a list of names.

The cost of this form: contrib.rocks cannot be pinned by SHA. If it goes away the image breaks, and the link under it still resolves to the graph.

`sf check --allow-commands --changed main` is clean locally: 27 rules, no findings.