### PR TITLE
feat(L1): a skipped test says why in every language sf parses

### DIFF
--- a/.github/workflows/software-factory.yml
+++ b/.github/workflows/software-factory.yml
@@ -28,6 +28,13 @@ jobs:
       # right for a consumer and wrong here — do not regenerate this file.
       - name: Build
         run: cargo build --release --locked
+      # No job ran these until now, so the assertions this repository wrote
+      # about itself — the `include_str!` registries matching their
+      # directories, a shipped query matching what it claims — were only ever
+      # checked on somebody's laptop. That is the same failure as a check that
+      # stopped firing: green, and meaning nothing.
+      - name: Unit tests
+        run: cargo test --locked
       # verify first: a check that stopped firing makes the run below
       # meaningless, and it is the cheaper failure to discover.
       - name: Prove the checks still fire

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -4,7 +4,7 @@
     ".allowed-root-files": "20889fd9828de3c601e63bae4c430692846319df116688c1322bd230bdfc1995",
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
     ".github/workflows/software-factory.yml": "6516720f73d96eca7703514ff84810d74b88f836960cd8a7f307da67761840ef",
-    ".software-factory/policy.yaml": "afaf83772538b9f49d455f187061fe026031b8b1602e86ca76379034553655d6",
+    ".software-factory/policy.yaml": "ff4ccc1c59ed24ae74aa39ea86eb531ae78355c8fa121b1f7cdc902fc533e0d4",
     ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"
   }
 }

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -3,7 +3,7 @@
   "files": {
     ".allowed-root-files": "20889fd9828de3c601e63bae4c430692846319df116688c1322bd230bdfc1995",
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
-    ".github/workflows/software-factory.yml": "6516720f73d96eca7703514ff84810d74b88f836960cd8a7f307da67761840ef",
+    ".github/workflows/software-factory.yml": "0350f6ff218f228765453461949d2c9b7ce5158c0705a7968c332a7b629f7eab",
     ".software-factory/policy.yaml": "ff4ccc1c59ed24ae74aa39ea86eb531ae78355c8fa121b1f7cdc902fc533e0d4",
     ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"
   }

--- a/.software-factory/mutations/L1.SKIPPED_TESTS_STATE_A_REASON/tests/billing.rs
+++ b/.software-factory/mutations/L1.SKIPPED_TESTS_STATE_A_REASON/tests/billing.rs
@@ -1,0 +1,5 @@
+#[test]
+#[ignore]
+fn refund_is_idempotent() {
+    assert!(true);
+}

--- a/.software-factory/mutations/L1.SKIPPED_TESTS_STATE_A_REASON/tests/billing.test.ts
+++ b/.software-factory/mutations/L1.SKIPPED_TESTS_STATE_A_REASON/tests/billing.test.ts
@@ -1,0 +1,6 @@
+describe("refunds", () => {
+  it.skip("is idempotent", () => {});
+
+  // Flaky against the sandbox gateway; back when TICKET-4711 lands.
+  it.skip("settles twice", () => {});
+});

--- a/.software-factory/mutations/L1.SKIPPED_TESTS_STATE_A_REASON/tests/billing_test.go
+++ b/.software-factory/mutations/L1.SKIPPED_TESTS_STATE_A_REASON/tests/billing_test.go
@@ -1,0 +1,7 @@
+package billing
+
+import "testing"
+
+func TestRefundIsIdempotent(t *testing.T) {
+	t.Skip()
+}

--- a/.software-factory/policy.yaml
+++ b/.software-factory/policy.yaml
@@ -47,12 +47,10 @@ rules:
       # suppression from a string that quotes one; excluding the one file that
       # is deliberately full of them is narrower than weakening the rule.
       exclude: ["src/fixtures.rs"]
-  # L1 — The untyped escape hatch is banned, and the message names the alternative
+  # L1 — A skipped or expected-to-fail test says why
   L1.SKIPPED_TESTS_STATE_A_REASON:
-    # Disabled: the rule ships a Python query only, and this is a Rust
-    # repository. Same reasoning as the other rules switched off below — it
-    # stays proven by its fixture, it is simply not about this codebase.
-    enabled: false
+    enabled: true
+  # L1 — The untyped escape hatch is banned, and the message names the alternative
   L1.NO_UNTYPED_ESCAPE_HATCH:
     enabled: true
     options:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,15 @@ whose vocabulary does not exist in that language simply omit it — a rule with
 no query for a language does not apply to it, and that is the correct outcome,
 not a gap to paper over.
 
+The exception is a rule whose vocabulary *does* exist there but whose
+acceptable form is a sibling rather than an argument. A tree-sitter query
+cannot say "unless a comment sits above this", so `kind: shape` takes an
+optional second query per language, `unless`, matching the same shape plus what
+makes it acceptable; its `@target` lines cancel the first query's. Two positive
+queries and a set difference, which is how the `text_pattern` rules already
+read. Add the accepted form to the fixture next to the violating one — it is
+the only way a mutation can be about a rule staying quiet.
+
 A rule that can't be decided structurally — its truth only comes out of
 running something, not matching a query — takes `kind: command` instead of a
 grammar. That is the extension point for a check this tool cannot express:

--- a/README.md
+++ b/README.md
@@ -453,6 +453,21 @@ a constraint on where matches may live. The engine knows nothing about
 controllers, repositories or exceptions — that vocabulary lives entirely in the
 catalog, which is what lets one rule mean the same thing in four languages.
 
+A language may also carry an `unless` query: the same shape plus whatever makes
+it acceptable, whose matches cancel the ones above on that line. It exists
+because negation over siblings is not expressible in a tree-sitter query, and
+some rules need it — `L1.SKIPPED_TESTS_STATE_A_REASON` asks a TypeScript skip
+for a comment on the line above, because `it.skip('name', fn)` has no parameter
+for a reason and a comment is the only place one can live.
+
+```yaml
+    typescript:
+      query: |
+        (expression_statement (call_expression ... )) @target
+      unless: |
+        ((comment) . (expression_statement (call_expression ... )) @target)
+```
+
 **Adding a language** is a grammar plus one query per rule you want it to
 cover. **Adding a rule** is a YAML file in `.software-factory/rules/` and a
 fixture under `.software-factory/mutations/<RULE_ID>/`.

--- a/catalog/L1/skipped-tests-state-a-reason.yaml
+++ b/catalog/L1/skipped-tests-state-a-reason.yaml
@@ -3,8 +3,11 @@ layer: L1
 title: A skipped or expected-to-fail test says why
 severity: medium
 statement: >-
-  `skip` and `xfail` are called with something in them — a reason string, a
-  `reason=`, a condition. An empty call is a finding.
+  A disabled test carries its reason. Where the test API takes one —
+  `pytest.mark.skip`, `t.Skip`, `#[ignore]` — it is called with something in
+  it: a reason string, a `reason=`, a condition. Where the API takes no reason
+  at all, which is every JavaScript test runner, the reason is a comment on the
+  line above. Nothing at all is a finding.
 why: >-
   A skipped test is a hole in coverage that reports as green, and the only
   thing standing between "temporarily disabled while I fix the fixture" and
@@ -14,10 +17,22 @@ why: >-
   This is deliberately an AST rule rather than a line pattern. A real skip
   spans several lines and states its reason on the second one, so a line-based
   check flags every correct skip in the repository — which teaches people to
-  ignore the rule, and is worse than not having it.
+  ignore the rule, and is worse than not having it. It is also what keeps this
+  rule quiet about `it.skip` written inside a string literal, and about a
+  lexer's own `.skip()`, neither of which is a skipped test.
+  The typescript form is the same rule with a weaker place to put the answer.
+  `it.skip('name', fn)` has no parameter for a reason and neither jest nor
+  vitest ever added one, so a comment is the only place a reason can live —
+  and asking for it is still the whole point, because the reason is what makes
+  the skip reviewable. A conditional skip (`it.skipIf`, `describe.runIf`)
+  already says why in the condition, which is why it is not a finding.
 fix: >-
   Say why, and say when it comes back. If the reason is "it fails and I do not
-  know why", that is the finding, not the fix.
+  know why", that is the finding, not the fix. In python, go and rust, pass it:
+  `@pytest.mark.skip(reason="...")`, `t.Skip("...")`,
+  `#[ignore = "..."]`. In typescript, write it on the line above the skip. If
+  the skip is permanent, delete the test — a test nobody intends to re-enable
+  is documentation that claims to be a check.
 ratchet: allowlist
 check:
   kind: shape
@@ -29,6 +44,71 @@ check:
           arguments: (argument_list) @args
           (#match? @name "^(skip|xfail)$")
           (#match? @args "^\\(\\s*\\)$")) @target
+    typescript:
+      # `@recv` is matched as text rather than as a node so that
+      # `it.concurrent.skip` is the same finding as `it.skip`: the receiver is a
+      # member expression in one case and an identifier in the other, and the
+      # hazard is identical.
+      query: |
+        (expression_statement
+          (call_expression
+            function: (member_expression
+              object: (_) @recv
+              property: (property_identifier) @name))
+          (#match? @recv "^(it|test|describe|suite)\\b")
+          (#match? @name "^(skip|todo|failing|fails)$")) @target
+        (expression_statement
+          (call_expression
+            function: (identifier) @name)
+          (#match? @name "^(xit|xtest|xdescribe)$")) @target
+      # The reason, in the only place JavaScript leaves for it. Anchored
+      # adjacency, so a comment three statements up does not launder the skip
+      # below it.
+      unless: |
+        ((comment)
+          .
+          (expression_statement
+            (call_expression
+              function: (member_expression
+                object: (_) @recv
+                property: (property_identifier) @name))
+            (#match? @recv "^(it|test|describe|suite)\\b")
+            (#match? @name "^(skip|todo|failing|fails)$")) @target)
+        ((comment)
+          .
+          (expression_statement
+            (call_expression
+              function: (identifier) @name)
+            (#match? @name "^(xit|xtest|xdescribe)$")) @target)
+    go:
+      # `t.Skipf` cannot be called empty and `t.SkipNow` cannot be called with
+      # anything, so neither is decidable here. `Skip` is the one that takes a
+      # reason and can be robbed of it.
+      query: |
+        (call_expression
+          function: (selector_expression field: (field_identifier) @name)
+          arguments: (argument_list) @args
+          (#match? @name "^Skip$")
+          (#match? @args "^\\(\\s*\\)$")) @target
+    rust:
+      # Anchors on both sides: `#[ignore]` has the identifier as its only
+      # child, `#[ignore = "flaky under load"]` carries the reason after it.
+      query: |
+        (attribute_item
+          (attribute . (identifier) @name .)
+          (#eq? @name "ignore")) @target
 defaults:
-  scope: ["**/tests/**", "**/test_*.py", "**/*_test.py"]
+  scope:
+    - "**/tests/**"
+    - "**/test_*.py"
+    - "**/*_test.py"
+    - "**/*.test.ts"
+    - "**/*.test.tsx"
+    - "**/*.spec.ts"
+    - "**/*.spec.tsx"
+    - "**/*_test.go"
+    # Rust tests live in the file they test, inside `#[cfg(test)]`, so there is
+    # no test-file glob to scope to. The query only matches an `ignore`
+    # attribute, which nothing but a test carries.
+    - "**/*.rs"
   must_not_live_in: ["**"]

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -100,6 +100,16 @@ Do not introduce the language's "anything goes" type. Ban it where it is introdu
 
 **Fix.** Use a TypedDict/interface/struct for a known shape, a generic parameter for genuine passthrough, or the project's JSON value type at a serialization boundary. If a third-party stub truly forces it, suppress that one line with a reason.
 
+### L1.SKIPPED_TESTS_STATE_A_REASON
+
+**A skipped or expected-to-fail test says why**
+
+A disabled test carries its reason. Where the test API takes one — `pytest.mark.skip`, `t.Skip`, `#[ignore]` — it is called with something in it: a reason string, a `reason=`, a condition. Where the API takes no reason at all, which is every JavaScript test runner, the reason is a comment on the line above. Nothing at all is a finding.
+
+**Why.** A skipped test is a hole in coverage that reports as green, and the only thing standing between "temporarily disabled while I fix the fixture" and "permanently disabled, nobody remembers why" is the sentence next to it. Skipping is also the cheapest way to turn a red suite green, and at the diff level it is indistinguishable from a fix. This is deliberately an AST rule rather than a line pattern. A real skip spans several lines and states its reason on the second one, so a line-based check flags every correct skip in the repository — which teaches people to ignore the rule, and is worse than not having it. It is also what keeps this rule quiet about `it.skip` written inside a string literal, and about a lexer's own `.skip()`, neither of which is a skipped test. The typescript form is the same rule with a weaker place to put the answer. `it.skip('name', fn)` has no parameter for a reason and neither jest nor vitest ever added one, so a comment is the only place a reason can live — and asking for it is still the whole point, because the reason is what makes the skip reviewable. A conditional skip (`it.skipIf`, `describe.runIf`) already says why in the condition, which is why it is not a finding.
+
+**Fix.** Say why, and say when it comes back. If the reason is "it fails and I do not know why", that is the finding, not the fix. In python, go and rust, pass it: `@pytest.mark.skip(reason="...")`, `t.Skip("...")`, `#[ignore = "..."]`. In typescript, write it on the line above the skip. If the skip is permanent, delete the test — a test nobody intends to re-enable is documentation that claims to be a check.
+
 ## L2 — Contract: no drift from the source of truth
 
 ### L2.DEPENDENCIES_CHANGE_DELIBERATELY

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -14,6 +14,8 @@ precondition exists. Park it in the second table rather than deleting it.
 
 | 3 | [Text renderer shows `expected` even when `actual` is absent](text-renderer-shows-expected-without-actual.md) | A finding produced by any check that sets `expected` without `actual` shows that field in `sf check`'s text output, proven by the `L4.ROOT_FILES_ARE_DECLARED` mutation fixture and a stray-root-file check naming `.allowed-root-files`. |
 
+| 4 | [`L1.SKIPPED_TESTS_STATE_A_REASON` in every language `sf` parses](skipped-tests-say-why-in-every-language.md) | A TypeScript repository with a bare `it.skip` fails `sf check` on it, this repository enables the rule on its own Rust source, and `sf verify` proves it fires in all four languages. |
+
 ## Parked
 
 | Work | Waiting on |

--- a/plans/skipped-tests-say-why-in-every-language.md
+++ b/plans/skipped-tests-say-why-in-every-language.md
@@ -1,0 +1,88 @@
+# `L1.SKIPPED_TESTS_STATE_A_REASON` in every language `sf` parses
+
+The rule shipped one query, for Python. `sf` parses four languages, so in the
+other three the rule was enabled-and-inert — which is the state
+`L5.NO_INERT_RULE` exists to make impossible. Both repositories that use this
+tool had already written the workaround down:
+
+- this one, in `.software-factory/policy.yaml`: *"Disabled: the rule ships a
+  Python query only, and this is a Rust repository."*
+- `nicolasmelo-portfolio`, in `docs/rules.md`: *"The catalog ships a
+  python-only tree-sitter query for this rule and this repository is
+  typescript-only, so enabling it could never produce a finding. Turn it back
+  on if a python query lands upstream."*
+
+Two repositories disabling the same rule for the same reason is not a policy
+decision, it is a missing query. A skipped test that reports green is not a
+Python problem.
+
+## Why the three new queries are not one query
+
+Go and Rust are the direct translation of the Python one — the reason is an
+argument the API accepts and the violation is the call made without it:
+`t.Skip()` against `t.Skip("...")`, `#[ignore]` against
+`#[ignore = "..."]`. Both are matched with anchors so the *presence* of the
+reason is what cancels the finding, which keeps the rule's meaning identical
+across three languages.
+
+TypeScript is the one that needed a decision. `it.skip('name', fn)` has no
+parameter for a reason, and neither jest nor vitest ever added one, so the
+direct translation is a query that can never fire — the same inert rule, now
+with a query to make it look covered. Two other options were considered and
+rejected:
+
+- **Flag every skip, and freeze the legitimate ones in the ratchet.** This is
+  what `L6.ONE_LOCK_AT_A_TIME` does with a lock pair it cannot judge, and the
+  ratchet is a better place for a reason than a comment: it carries a
+  `review_by` date and `L2.NO_PERMANENT_EXCEPTION` fails when it expires. It
+  was rejected because it makes the rule mean something different in
+  TypeScript than the title claims — "a skipped test says why" becomes "there
+  are no skipped tests" — and rule ids are a public contract.
+- **A line pattern.** Already argued against in the rule's own `why`: a real
+  skip spans several lines and a line-based check flags the correct ones,
+  which teaches people to ignore the rule.
+
+What is left is the comment on the line above, which is the only place
+JavaScript leaves for a reason. It is weaker evidence than a `reason=`
+argument in exactly one way — nothing parses it — and identical in every other
+way, including that both are prose nobody verifies.
+
+## What the engine was missing
+
+"This shape, unless a comment sits above it" is not expressible as one
+tree-sitter query: negation over siblings does not exist in the query
+language. `LangQuery` therefore gained an optional second query, `unless`,
+matching the same shape *plus* what makes it acceptable; `shape.rs` subtracts
+its `@target` lines from the first query's. Two positive queries and a set
+difference, which is the same shape as `forbidden`/`unless` in the
+`text_pattern` rules — the reader already knows the idiom.
+
+Deliberately out of scope: the three concurrency rules that
+`nicolasmelo-portfolio` also documents as not enabled
+(`L6.DATA_RACES_ARE_DETECTED`, `L6.NO_BLOCKING_CALL_WHILE_HOLDING_A_LOCK`,
+`L6.ONE_LOCK_AT_A_TIME`). Those are not missing queries. JavaScript has no
+lock to hold and no shared mutable state across threads to race on, and the
+ecosystem ships no dynamic race detector to wire in. Writing a TypeScript
+query for them is exactly the "inventing a query so the coverage table looks
+full" that [expand-language-adapters.md](expand-language-adapters.md) warns
+against.
+
+**Exit condition:** a TypeScript repository with a bare `it.skip` fails
+`sf check` on it, this repository enables the rule on its own Rust source
+instead of documenting why it cannot, and `sf verify` proves the rule fires in
+all four languages.
+
+## Acceptance criteria
+
+- [x] The rule fires on a bare skip in python, typescript, go and rust, and
+      `sf verify` refuses to pass on three of four
+      (proof: test:.software-factory/mutations/L1.SKIPPED_TESTS_STATE_A_REASON/)
+- [x] A TypeScript skip with a comment on the line above produces no finding,
+      while the same skip without one does
+      (proof: test:src/checks/shape.rs::cancelling_query)
+- [x] This repository enables `L1.SKIPPED_TESTS_STATE_A_REASON` and stays green
+      (proof: test:.software-factory/policy.yaml)
+- [ ] `nicolasmelo-portfolio` re-enables the rule and deletes its
+      "deliberately disabled" section
+      (proof: deferred:a pull request in that repository, once this is merged
+      and its CI installs an `sf` that carries the query)

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -48,6 +48,13 @@ impl Layer {
 pub struct LangQuery {
     /// A tree-sitter query. It must bind `@target`, and may bind `@name`.
     pub query: String,
+    /// The same shape, matched only where it is accompanied by what makes it
+    /// acceptable — a `@target` here cancels the one `query` found on that
+    /// line. A tree-sitter query cannot say "unless a comment sits above
+    /// this", because negation over siblings is not expressible; two positive
+    /// queries and a set difference say it, and stay readable.
+    #[serde(default)]
+    pub unless: Option<String>,
 }
 
 /// A containment rule: `inner` must not appear anywhere inside `outer`.
@@ -182,6 +189,9 @@ fn validate_patterns(options: &crate::policy::Options) -> Result<()> {
 fn validate_queries(languages: &BTreeMap<String, LangQuery>) -> Result<()> {
     for (name, spec) in languages {
         validate_query(name, &spec.query)?;
+        if let Some(unless) = &spec.unless {
+            validate_query(name, unless)?;
+        }
     }
     Ok(())
 }

--- a/src/checks/shape.rs
+++ b/src/checks/shape.rs
@@ -13,7 +13,7 @@ use crate::lang::Lang;
 use crate::policy::Options;
 use crate::scan;
 use anyhow::{Context, Result};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator};
 
 struct Match {
@@ -57,9 +57,31 @@ fn collect(
         let Ok(source) = std::fs::read_to_string(&file.abs) else {
             continue;
         };
-        matches.extend(query_file(rule, lang, &spec.query, &file.rel, &source)?);
+        matches.extend(matches_in(rule, lang, spec, &file.rel, &source)?);
     }
     Ok(matches)
+}
+
+/// Every match of `query` that `unless` does not cancel.
+///
+/// The cancelling query matches the same shape plus whatever makes it
+/// acceptable, so the two agree on the `@target` line and the difference is a
+/// line-set subtraction. Kept separate from `collect` so it can be tested
+/// against the catalog's real queries without a repository around it.
+fn matches_in(
+    rule: &Rule,
+    lang: Lang,
+    spec: &LangQuery,
+    rel: &str,
+    source: &str,
+) -> Result<Vec<Match>> {
+    let found = query_file(rule, lang, &spec.query, rel, source)?;
+    let Some(unless) = &spec.unless else {
+        return Ok(found);
+    };
+    let accepted: BTreeSet<usize> =
+        query_file(rule, lang, unless, rel, source)?.into_iter().map(|m| m.line).collect();
+    Ok(found.into_iter().filter(|m| !accepted.contains(&m.line)).collect())
 }
 
 fn query_file(
@@ -167,4 +189,47 @@ fn density(rule: &Rule, opts: &Options, matches: &[Match]) -> Vec<Finding> {
 
 fn trim_quotes(s: &str) -> String {
     s.trim_matches(|c| c == '"' || c == '\'' || c == '`').to_string()
+}
+
+#[cfg(test)]
+mod cancelling_query {
+    use super::*;
+    use crate::catalog::{Catalog, CheckKind};
+
+    const TESTS: &str = "describe(\"refunds\", () => {\n  \
+        it.skip(\"is idempotent\", () => {});\n\n  \
+        // Flaky against the sandbox gateway; back when TICKET-4711 lands.\n  \
+        it.skip(\"settles twice\", () => {});\n});\n";
+
+    fn typescript(rule_id: &str) -> (crate::catalog::Rule, LangQuery) {
+        let catalog = Catalog::builtin().expect("the builtin catalog loads");
+        let rule = catalog.get(rule_id).expect("the rule ships in the catalog").clone();
+        let CheckKind::Shape { languages } = &rule.check else {
+            panic!("{rule_id} is not a shape rule");
+        };
+        let spec = languages.get("typescript").expect("the rule ships a typescript query").clone();
+        (rule, spec)
+    }
+
+    /// The pair that makes `unless` meaningful: the query has to see both
+    /// skips, or the filter below proves nothing.
+    #[test]
+    fn the_query_alone_matches_every_skip() {
+        let (rule, spec) = typescript("L1.SKIPPED_TESTS_STATE_A_REASON");
+        let found = query_file(&rule, Lang::TypeScript, &spec.query, "billing.test.ts", TESTS)
+            .expect("the typescript query is valid");
+        assert_eq!(found.iter().map(|m| m.line).collect::<Vec<_>>(), vec![2, 5]);
+    }
+
+    #[test]
+    fn a_comment_above_the_skip_cancels_it() {
+        let (rule, spec) = typescript("L1.SKIPPED_TESTS_STATE_A_REASON");
+        let found = matches_in(&rule, Lang::TypeScript, &spec, "billing.test.ts", TESTS)
+            .expect("both typescript queries are valid");
+        assert_eq!(
+            found.iter().map(|m| m.line).collect::<Vec<_>>(),
+            vec![2],
+            "the documented skip on line 5 should be cancelled, the bare one on line 2 should not"
+        );
+    }
 }

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -120,10 +120,28 @@ pub const FIXTURES: &[Fixture] = &[
         rule: "L1.SKIPPED_TESTS_STATE_A_REASON",
         policy_extra: "",
         extra_rules: "",
-        files: &[(
-            "tests/test_billing.py",
-            "@pytest.mark.skip()\ndef test_refund_is_idempotent():\n    ...\n",
-        )],
+        files: &[
+            (
+                "tests/test_billing.py",
+                "@pytest.mark.skip()\ndef test_refund_is_idempotent():\n    ...\n",
+            ),
+            // Two skips on purpose: the first is the violation, the second is
+            // the accepted form. If the `unless` query ever stops matching,
+            // the second one starts producing a finding here — which is the
+            // only way a fixture can be about a rule staying quiet.
+            (
+                "tests/billing.test.ts",
+                "describe(\"refunds\", () => {\n  it.skip(\"is idempotent\", () => {});\n\n  // Flaky against the sandbox gateway; back when TICKET-4711 lands.\n  it.skip(\"settles twice\", () => {});\n});\n",
+            ),
+            (
+                "tests/billing_test.go",
+                "package billing\n\nimport \"testing\"\n\nfunc TestRefundIsIdempotent(t *testing.T) {\n\tt.Skip()\n}\n",
+            ),
+            (
+                "tests/billing.rs",
+                "#[test]\n#[ignore]\nfn refund_is_idempotent() {\n    assert!(true);\n}\n",
+            ),
+        ],
     },
     Fixture {
         rule: "L1.NO_UNTYPED_ESCAPE_HATCH",


### PR DESCRIPTION
`L1.SKIPPED_TESTS_STATE_A_REASON` shipped one query, for Python. `sf` parses four languages, so in the other three the rule was enabled and inert, which is the state `L5.NO_INERT_RULE` exists to make impossible. Both repositories using this tool had already written the workaround down:

- here, in `.software-factory/policy.yaml`: "Disabled: the rule ships a Python query only, and this is a Rust repository."
- `nicolasmelo-portfolio`, in `docs/rules.md`: "The catalog ships a python-only tree-sitter query for this rule and this repository is typescript-only, so enabling it could never produce a finding. Turn it back on if a python query lands upstream."

## What changed

- **Go and Rust**: the direct translation, the reason is an argument the API accepts. `t.Skip()` against `t.Skip("...")`, `#[ignore]` against `#[ignore = "..."]`, both anchored so the presence of the reason is what cancels the finding.
- **TypeScript**: `it.skip('name', fn)` has no parameter for a reason, and neither jest nor vitest ever added one, so the reason lives in a comment on the line above. "This shape unless a comment sits above it" is not expressible as one tree-sitter query, negation over siblings does not exist in the query language. `LangQuery` takes an optional second query, `unless`, matching the same shape plus what makes it acceptable, and `shape.rs` subtracts its `@target` lines. Same idea as `forbidden`/`unless` in the `text_pattern` rules.
- A conditional skip (`it.skipIf`, `describe.runIf`) says why in the condition, so it is not a finding.
- This repository enables the rule on its own Rust source instead of documenting why it cannot.

Two options were rejected, both argued in [the plan](plans/skipped-tests-say-why-in-every-language.md): flagging every TypeScript skip and freezing the legitimate ones in the ratchet (it makes the rule mean something the title does not claim, and rule ids are a contract), and a line pattern (already argued against in the rule's own `why`).

## Proof

- `sf verify` now trips the rule in all four languages. The fixture carries a documented skip next to the bare one, and `cargo test` runs the shipped query over both, which is the only way a mutation can be about a rule staying quiet.
- Probed against `nicolasmelo-portfolio` with this binary: a bare `it.skip` produces `lib/probe.test.ts:4 — skip appears where this rule forbids it`, the same skip with a comment above produces nothing, and the `describe.skipIf(!live)` already in that repo stays quiet.
- `sf verify` 28/28, `sf check` clean, `cargo clippy --all-targets -- -D warnings -D dead_code` clean.

## Out of scope

The three concurrency rules `nicolasmelo-portfolio` also documents as not enabled. Those are not missing queries: JavaScript has no lock to hold, no shared mutable state across threads, and no dynamic race detector to wire in. Writing a query for them is the "inventing a query so the coverage table looks full" that `plans/expand-language-adapters.md` warns against.

The follow-up PR in `nicolasmelo-portfolio` (enable the rule, delete the "deliberately disabled" section) waits on this merging, since its CI installs `sf` from `main`.

## One more thing this turned up

`cargo test` was never in the workflow, so the completeness assertions from 8c94c27 and the query test in this branch only ever ran on a laptop. Added as a step before `sf verify`.
