### PR TITLE
docs(plans): third-party conformance and claim drift

### DIFF
--- a/plans/claims-cite-their-evidence.md
+++ b/plans/claims-cite-their-evidence.md
@@ -1,0 +1,87 @@
+# Claims cite the evidence that proves them
+
+A landing page and a README make promises. Nothing here joins a promise to the
+thing that proved it, so the two come apart the ordinary way: the promise was
+true when it was written, the code moved, and the sentence stayed.
+
+The reference half of documentation should not be checked at all, it should be
+generated. `docs/rules.md` is generated from `catalog/`, and
+`L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE` runs `sf docs` and diffs the result,
+so it cannot sit out of date with the rules it describes. Every SDK reference
+page should be built that way, and then this rule has nothing to say about it.
+
+This plan is about the other half: prose with no source to be generated from.
+A landing page, a "what this does" section, a benchmark number in a README.
+
+## The primitive already exists
+
+`L4.EVERY_RULE_HAS_A_WHY` is a bidirectional citation check. Every enabled rule
+must be cited in prose, and every rule id appearing in prose must exist in the
+catalog. Its marker is a configurable regex and its scope is a glob
+([`src/checks/cadence.rs`](../src/checks/cadence.rs)). The only hard-wired part
+is what a citation resolves *against*, which is the catalog.
+
+Point the same engine at gates:
+
+```
+<!-- claim: IMPORT_50K_UNDER_60S proven-by: bulk-import -->
+Import fifty thousand rows in under a minute.
+```
+
+`proven-by` names a key in `gates:` in the policy. A claim naming a gate that
+is not there fails. A gate that is there carries evidence, and
+`L3.GATE_HAS_FRESH_EVIDENCE` already fails when the implementation digest of
+the activation paths has moved, so the promise goes red *through* the gate.
+Writing a second freshness check here would be a worse copy of the one that
+already works.
+
+The rule is not named here on purpose. `L4.EVERY_RULE_HAS_A_WHY` resolves rule
+ids in every markdown file, this one included, so a plan that picks an id for a
+rule it has not written yet fails the check that plan is about to extend. The
+id is chosen in the commit that writes the rule.
+
+## Three decisions
+
+**Two directions, not three.** Every claim names a proof, and every named gate
+exists. The third direction, every gate is claimed somewhere, is wrong: most
+gates have nothing to do with a marketing page.
+
+**A claim id, not just a gate reference.** The id is what survives an edit of
+the sentence. Without it, moving a promise into another paragraph reads as one
+claim deleted and another added, and the reviewer loses the thread of which
+promise was ever proven.
+
+**The marker is a comment, not syntax.** It has to work in markdown, MDX and
+HTML without a build step, and it has to be invisible in the rendered page.
+
+## What this does not do
+
+It cannot enumerate the promises on a page, so it cannot notice a new unmarked
+one. That limit belongs in the rule's `why`, stated, not implied.
+
+It also does not verify that the sentence means what the gate proved. Only a
+reader does that, human or model, and it happens once, when the promise is
+written. What CI gets for free is the join: the proof exists, it is enabled,
+and it is not certifying code that has since changed. That is where the drift
+actually lives, because a promise is rarely written false, it ages into false.
+
+**Exit condition:** a claim marker in a scoped page naming a gate that is not
+in the policy fails `sf check`, and a claim whose gate lost its evidence to a
+code change fails through `L3.GATE_HAS_FRESH_EVIDENCE`, both proven by mutation
+fixtures.
+
+## Acceptance criteria
+
+- [ ] A cadence mode `claim_citations` resolves claim markers against `gates:`
+      and fails on a gate the policy does not declare
+      (proof: deferred:the mutation fixture for the new L4 rule, written in the
+      same commit as the rule)
+- [ ] A claim marker that parses but names no gate fails the same way a
+      criterion with no proof marker does
+      (proof: deferred:same fixture as above)
+- [ ] Changing the code behind a claimed gate turns the page red with no
+      freshness logic added to this mode
+      (proof: test:.software-factory/mutations/L3.GATE_HAS_FRESH_EVIDENCE/)
+- [ ] An unmarked promise is not detected, and the rule's `why` says so rather
+      than leaving it to be discovered
+      (proof: unspecified:no check can enumerate the promises on a page)

--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -16,7 +16,12 @@ precondition exists. Park it in the second table rather than deleting it.
 
 | 4 | [`L1.SKIPPED_TESTS_STATE_A_REASON` in every language `sf` parses](skipped-tests-say-why-in-every-language.md) | A TypeScript repository with a bare `it.skip` fails `sf check` on it, this repository enables the rule on its own Rust source, and `sf verify` proves it fires in all four languages. |
 
+| 5 | [Claims cite the evidence that proves them](claims-cite-their-evidence.md) | A claim marker in a scoped page naming a gate the policy does not declare fails `sf check`, and a claim whose gate lost its evidence to a code change fails through `L3.GATE_HAS_FRESH_EVIDENCE`, both proven by fixtures. |
+
+| 6 | [Rules activate on the version of the dependency they are about](rules-activate-by-dependency-version.md) | Changing a dependency's pin in the manifest makes `sf check` fail by naming every rule whose `when` no longer matches, instead of leaving them enabled and inert. |
+
 ## Parked
 
 | Work | Waiting on |
 | --- | --- |
+| [Rule packs for third-party APIs and libraries](third-party-rule-packs.md) | Version-conditional activation (#6). A pack that cannot say which upstream version it describes is a pack somebody has to remember to remove, which is the state it exists to fix. |

--- a/plans/rules-activate-by-dependency-version.md
+++ b/plans/rules-activate-by-dependency-version.md
@@ -1,0 +1,91 @@
+# Rules activate on the version of the dependency they are about
+
+A deprecation rule for Tailwind 3, or a shape rule for the QuickBooks v3 API,
+is only correct while that version is the one installed. Today a rule instance
+is on or off and nothing connects it to the manifest, so the correctness of the
+policy depends on somebody remembering.
+
+Two failure modes. The second is the expensive one.
+
+**A rule for a version you no longer run.** The pin moves to Tailwind 4, the v3
+rules keep firing on code that is now right, and the cheapest way to green is to
+widen an exclusion. That is the exact move `L2.POLICY_ONLY_TIGHTENS` exists to
+make visible, so it is noisy rather than dangerous.
+
+**A rule that quietly stops applying.** The pin moves, the patterns no longer
+match anything, and the rule reports green forever. `L5.NO_INERT_RULE` catches
+structural inertness today, an empty lock scope, a command with no `run`, a
+query for no declared language, but it cannot catch a `text_pattern` rule whose
+regexes describe an API nobody calls anymore. It reads exactly like a rule that
+is protecting you.
+
+## The shape
+
+```yaml
+rules:
+  # PACK_RULE_ID stands in for the pack's own id. A plan cannot name an
+  # unwritten rule: `L4.EVERY_RULE_HAS_A_WHY` reads this file too.
+  PACK_RULE_ID@tailwind3:
+    enabled: true
+    when:
+      dependency: tailwindcss
+      manifest: package.json
+      version: "^3"
+```
+
+The version comes from the manifest, which is already inside the scope of
+`L2.DEPENDENCIES_CHANGE_DELIBERATELY` (see
+[`.software-factory/policy.yaml`](../.software-factory/policy.yaml)). That is
+what makes the condition trustworthy: the input cannot move without a lock
+update in the same commit, so `when` is gated by a rule that already exists
+rather than being a new thing to trust.
+
+## Decisions
+
+**A `when` that does not match is a finding, not a skip.** This is the whole
+point. A rule whose condition went false announces that it no longer applies
+and names the version it expected against the version found, so the answer is
+to remove it or repoint it. Silently disabling itself is how a policy becomes
+decoration, and it would hand an agent a way to turn a rule off by editing a
+dependency. The finding belongs in `L5.NO_INERT_RULE`, whose vocabulary this
+already is.
+
+**The manifest range, not the resolved lock version.** The lock is more
+accurate and there are four lock formats per ecosystem, each with its own
+schema and its own churn. The manifest range is what the team decided, and the
+decision is what the rule is about.
+
+**Declared dependencies only.** A `when` naming a package no manifest declares
+is a finding, same as a condition that went false. A rule about a transitive
+dependency is a rule about somebody else's choice, and it will break on a
+resolution nobody made.
+
+## What this does not do
+
+It does not check that the rule's content is right for the version it claims.
+A regex written for Tailwind 3 stays a regex written for Tailwind 3 whether or
+not the condition matches. Reading the upstream changelog and turning it into
+patterns is a once-per-bump job for a model, not something CI can decide, and
+it is the job [`factory-author`](../skills/factory-author/SKILL.md) exists for.
+
+**Exit condition:** a repository pinned to a major version runs that version's
+rules, and changing the pin in the manifest makes `sf check` fail by naming
+every rule whose `when` no longer matches, instead of leaving them enabled and
+inert.
+
+## Acceptance criteria
+
+- [ ] `when: {dependency, manifest, version}` parses in the policy and decides
+      whether a rule instance runs
+      (proof: test:src/policy.rs)
+- [ ] A rule instance whose `when` no longer matches produces a finding naming
+      the expected range and the version found
+      (proof: test:.software-factory/mutations/L5.NO_INERT_RULE/)
+- [ ] A `when` naming a dependency no manifest declares is a finding, not a
+      skip (proof: test:.software-factory/mutations/L5.NO_INERT_RULE/)
+- [ ] `sf verify` still proves every conditional rule fires, with the fixture
+      carrying the manifest that satisfies its condition
+      (proof: test:src/verify.rs)
+- [ ] Nothing reads a lock file to resolve a version
+      (proof: unspecified:an absence is not checkable, it is a review note on
+      the diff that adds `when`)

--- a/plans/third-party-rule-packs.md
+++ b/plans/third-party-rule-packs.md
@@ -1,0 +1,70 @@
+# Rule packs for third-party APIs and libraries
+
+The two rules that already carry third-party conformance are
+`L2.DEPENDENCIES_CHANGE_DELIBERATELY`, which pins the version, and
+`L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE`, which regenerates a client from a
+vendored spec and diffs the result. Between them they cover everything a vendor
+publishes in machine-readable form: an OpenAPI document, a WSDL, a `.d.ts`.
+
+What they do not cover is everything a vendor publishes as prose. A removed
+utility class, an endpoint that still responds but is documented as going away,
+an argument whose meaning changed. That knowledge exists once, in a migration
+guide, and today every team that needs it re-derives it by reading.
+
+A pack is that reading, written down once as rules, versioned against the
+upstream release it describes, and installed:
+
+```sh
+sf pack add tailwind@3
+```
+
+The model reads the changelog once and emits catalog-shaped YAML. CI then runs
+Rust, with no network and no model. The pack is the durable artifact, which is
+the only reason this is worth building: it moves the cost from every run to
+every upgrade.
+
+## The three hard parts
+
+**Trust.** A pack is data that a `kind: command` rule can turn into execution.
+Installing one from a URL is installing a script. Packs are either vendored
+into the repository at install time, where they sit in the diff and under
+`L2.FACTORY_CONFIG_IS_LOCKED` like every other rule file, or they are not
+worth having.
+
+**Proof.** `L5.EVERY_CHECK_HAS_A_MUTATION_TEST` says an enabled rule with
+nothing proving it fires is not a rule. A pack of forty rules and no fixtures
+is forty rules that report green and nobody has ever seen fail. Install must
+refuse a pack whose rules do not trip their own fixtures, which means `sf pack
+add` runs `sf verify` over the pack before writing anything.
+
+**Expiry.** A pack for a version you no longer run has to say so out loud, and
+that is what [rules-activate-by-dependency-version.md](rules-activate-by-dependency-version.md)
+builds. Without it, every pack is something to remember to remove.
+
+## Deliberately not in scope
+
+Fetching the vendor's current spec to see whether it moved. `sf check` does not
+touch the network, on purpose: a policy file travels with a clone. Comparing a
+vendored spec against upstream is a scheduled job with `--allow-commands`, and
+its output is a pull request that bumps the pack, not a red PR build.
+
+**Exit condition:** `sf pack add <name>@<version>` vendors a versioned set of
+rules with their fixtures into `.software-factory/rules/`, refuses any pack
+whose fixtures do not trip its own rules, and the installed rules deactivate
+with a finding when the dependency's major version moves.
+
+## Acceptance criteria
+
+- [ ] A pack is catalog-shaped rule YAML plus one mutation fixture per rule,
+      with no new format to learn
+      (proof: deferred:the catalog format is fixed, the packaging around it is
+      not designed yet)
+- [ ] `sf pack add` runs `sf verify` over the pack and writes nothing if any
+      rule fails to fire
+      (proof: deferred:depends on the install path, not designed yet)
+- [ ] Installed pack rules carry a `when` naming the dependency and version
+      they describe
+      (proof: deferred:blocked on rules-activate-by-dependency-version.md)
+- [ ] No pack is fetched or evaluated at check time
+      (proof: unspecified:an absence, enforced by review of the diff that adds
+      the subcommand)


### PR DESCRIPTION
Three plans for two questions the tool does not answer today: conformance with a third party's spec at a pinned version, and drift between what a page promises and what was actually proven. Nothing is implemented here, this is the design and the ordering.

**#5 [Claims cite the evidence that proves them](plans/claims-cite-their-evidence.md).** A new cadence mode resolving claim markers on a page against `gates:`. It reuses the configurable marker and scope that `rule_citations` already has, and adds no freshness logic of its own: `L3.GATE_HAS_FRESH_EVIDENCE` already expires evidence when the implementation digest moves, so a promise goes red through its gate. The reference half of docs is not in scope, that should be generated, which is what `L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE` already does for `docs/rules.md`.

**#6 [Rules activate on the version of the dependency they are about](plans/rules-activate-by-dependency-version.md).** A `when` on a rule instance, read from the manifest that `L2.DEPENDENCIES_CHANGE_DELIBERATELY` already gates, so the input to the condition cannot move without a lock update in the same commit. The load-bearing decision: a condition that goes false is a finding, not a skip. A rule that switches itself off is decoration, and it would hand an agent a way to disable a check by editing a dependency.

**Parked: [Rule packs for third-party APIs and libraries](plans/third-party-rule-packs.md).** Waiting on #6, because a pack that cannot say which upstream version it describes is a pack somebody has to remember to remove. Vendored into the repo, verified at install time, never fetched at check time.

### One thing this found about the method

The first draft named the rule ids it intends to create. `L4.EVERY_RULE_HAS_A_WHY` reprovou: its `*.md` glob crosses `/` and reaches `plans/`, so a plan naming an unwritten rule fails the check it is about to extend. Fixed by not naming them, and the plans say why. It is defensible, but it is a real constraint of the method that is written nowhere. Worth its own item if you agree.

### Checks

`sf verify` 28/28, `sf check --allow-commands` clean (1 pre-existing ratchet entry).
