### PR TITLE
feat(L4): rule prose may only name commands sf accepts

### DIFF
--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -4,7 +4,7 @@
     ".allowed-root-files": "20889fd9828de3c601e63bae4c430692846319df116688c1322bd230bdfc1995",
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
     ".github/workflows/software-factory.yml": "0350f6ff218f228765453461949d2c9b7ce5158c0705a7968c332a7b629f7eab",
-    ".software-factory/policy.yaml": "ff4ccc1c59ed24ae74aa39ea86eb531ae78355c8fa121b1f7cdc902fc533e0d4",
+    ".software-factory/policy.yaml": "1ec33335103920948771d6f88063eeb8e831638014685cbdc91800e99f77496d",
     ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"
   }
 }

--- a/.software-factory/mutations/L4.RULE_PROSE_NAMES_A_REAL_COMMAND/.software-factory/policy.yaml
+++ b/.software-factory/mutations/L4.RULE_PROSE_NAMES_A_REAL_COMMAND/.software-factory/policy.yaml
@@ -1,0 +1,13 @@
+# Generated mutation fixture for L4.RULE_PROSE_NAMES_A_REAL_COMMAND. It is supposed to fail.
+version: 1
+project:
+  name: mutation-L4.RULE_PROSE_NAMES_A_REAL_COMMAND
+  languages: [python, typescript, go, rust]
+docs:
+  scan: ["docs/**/*.md"]
+gates: {}
+rules:
+  L4.LOCAL_RULE_WITH_A_DEAD_COMMAND:
+    enabled: true
+  L4.RULE_PROSE_NAMES_A_REAL_COMMAND:
+    enabled: true

--- a/.software-factory/mutations/L4.RULE_PROSE_NAMES_A_REAL_COMMAND/.software-factory/rules/local-rule.yaml
+++ b/.software-factory/mutations/L4.RULE_PROSE_NAMES_A_REAL_COMMAND/.software-factory/rules/local-rule.yaml
@@ -1,0 +1,15 @@
+id: L4.LOCAL_RULE_WITH_A_DEAD_COMMAND
+layer: L4
+title: A local rule whose fix names a command that does not exist
+severity: low
+statement: Nothing in this fixture violates this rule; its prose is the mutation.
+why: A rule needs a reason, and this one exists to carry a dead command in its fix.
+fix: Regenerate the manifest with `sf evidence record`, then commit it.
+ratchet: allowlist
+check:
+  kind: text_pattern
+defaults:
+  scope: ["src/**"]
+  forbidden:
+    - regex: "a shape this fixture never contains"
+      message: "Unreachable: this rule is here for its prose, not its pattern."

--- a/.software-factory/policy.yaml
+++ b/.software-factory/policy.yaml
@@ -113,6 +113,9 @@ rules:
   # L4 — New top-level files are declared before they appear
   L4.ROOT_FILES_ARE_DECLARED:
     enabled: true
+  # L4 — Every command a rule's prose quotes is one this `sf` accepts
+  L4.RULE_PROSE_NAMES_A_REAL_COMMAND:
+    enabled: true
   # L5 — Every enabled rule has a mutation that proves it fires
   L5.EVERY_CHECK_HAS_A_MUTATION_TEST:
     enabled: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,13 @@ ships.
   tools, or a structural rule with no query for any language this repository
   declares. Disabled with a reason in `docs/rules.md` is honest; enabled and
   inert is a rule lying about its own coverage.
+- **Prose may only name commands this `sf` accepts.**
+  `L4.RULE_PROSE_NAMES_A_REAL_COMMAND` reads every `sf ...` a rule's statement,
+  why or fix quotes and compares it with the clap definition in `src/main.rs`,
+  so a fix written against a subcommand that does not exist yet fails the
+  check. Ship the command in the same change, or name the one that exists. A
+  unit test does the same sweep over the whole shipped catalog, including the
+  rules this repository has switched off.
 - **Never widen a rule to make a finding disappear.** If a rule is wrong, argue
   it in the prose and change it deliberately. Silently loosening a glob is
   indistinguishable from a fix at the diff level, which is exactly the failure

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ reduced to a single method:
 > once as a check that *fails*. And every check has a mutation that proves it
 > fires.**
 
-It ships 27 rules across seven layers — from where an error type may be defined
+It ships 33 rules across seven layers — from where an error type may be defined
 to whether your CI still runs a vulnerability scanner — plus 4 rule templates an
 interview fills in with your own package and directory names. It protects its
 own configuration, so an agent cannot reach a green build by turning a rule off.
@@ -215,7 +215,7 @@ could not run" and "the repository has violations": `3` bootstrap failed,
 The numbers are identity, not sequence — grouped by what they are
 about. The adoption order is below, and it is different.
 
-27 rules, plus 4 templates the interview instantiates with your own names.
+33 rules, plus 4 templates the interview instantiates with your own names.
 
 | | Layer | What it checks |
 |---|---|---|
@@ -824,8 +824,8 @@ method nobody will adopt.
 
 `sf` is written in Rust and Rust is one of its target languages, so this
 repository runs its own rules against its own source, with its own mutation
-fixtures, in its own CI: **23 rules enabled, 23 proven to fire, no findings.**
-Three of the 27 are switched off here and one is frozen with a review date,
+fixtures, in its own CI: **29 rules enabled, 29 proven to fire, no findings.**
+Four of the 33 are switched off here and one is frozen with a review date,
 each as a written decision in [`docs/rules.md`](docs/rules.md) — because
 `L5.NO_INERT_RULE` refuses to let a rule be enabled and pointed at nothing.
 

--- a/catalog/L2/dependencies-change-deliberately.yaml
+++ b/catalog/L2/dependencies-change-deliberately.yaml
@@ -11,7 +11,7 @@ why: >-
   solving something else. Forcing the lock to move in the same commit turns the
   reviewer's attention on at exactly the moment it is worth spending.
 fix: >-
-  If the dependency is intended, run `sf lock --update` in the same commit and
+  If the dependency is intended, run `sf lock` in the same commit and
   say in the message what it buys. If it is incidental, remove it.
 ratchet: none
 check:

--- a/catalog/L2/generated-files-are-locked.yaml
+++ b/catalog/L2/generated-files-are-locked.yaml
@@ -13,8 +13,8 @@ why: >-
   in a different pull request, where nobody connects the two. The lock makes
   the fork impossible instead of merely discouraged.
 fix: >-
-  Change the source and regenerate, then run `sf lock --update` in the same
-  commit so the lock diff is visible to the reviewer as a deliberate act.
+  Change the source and regenerate, then run `sf lock` in the same commit
+  so the lock diff is visible to the reviewer as a deliberate act.
 ratchet: none
 check:
   kind: lock

--- a/catalog/L4/rule-prose-names-a-real-command.yaml
+++ b/catalog/L4/rule-prose-names-a-real-command.yaml
@@ -1,0 +1,29 @@
+id: L4.RULE_PROSE_NAMES_A_REAL_COMMAND
+layer: L4
+title: Every command a rule's prose quotes is one this `sf` accepts
+severity: medium
+statement: >-
+  Every `sf ...` invocation quoted in an enabled rule's statement, why or fix
+  names a subcommand this binary has, with long flags that subcommand accepts.
+why: >-
+  A rule's `fix` is the only documentation an agent reliably reads, and it is
+  read at the one moment somebody is trying to comply. An invocation that never
+  existed sends that reader to a dead end and makes the rule itself look wrong,
+  which is how a guardrail loses the argument it should win. This is not
+  hypothetical: one L3 rule shipped telling people to regenerate evidence with
+  a subcommand that was never implemented, and nothing noticed, because
+  `L4.EVERY_RULE_HAS_A_WHY` checks that a rule id is cited, not that the text
+  around the citation is still true. The same drift arrives from the other
+  direction once rules travel: a rule written against a newer `sf` names a
+  subcommand the binary in this repository does not have yet. The accepted
+  surface is read out of the command-line definition itself, so it cannot
+  become a second list somebody forgets to update.
+fix: >-
+  Correct the invocation where the rule defines it, in the catalog entry or in
+  the `.software-factory/rules` file for a local rule, then run `sf docs` so
+  the generated prose follows. If the command named is the one that ought to
+  exist, that is a change to the tool and the prose is early rather than wrong.
+ratchet: allowlist
+check:
+  kind: cadence
+  mode: rule_commands

--- a/docs/method.md
+++ b/docs/method.md
@@ -134,6 +134,12 @@ Three separations, each of which fails a specific way when it collapses:
 - **One execution order.** A single ordered document, short on purpose, is what
   stops parallel agents from each choosing their own next priority.
 
+The same attachment applies to the guardrail's own prose. A rule's `fix` is
+read at the one moment somebody is trying to comply, so
+`L4.RULE_PROSE_NAMES_A_REAL_COMMAND` compares every command that prose quotes
+with the command-line definition itself: a fix that sends the reader to a
+subcommand this binary never had makes the whole rule look wrong.
+
 ### L5 — Meta: the guardrail is proven to fire, and is pointed at something
 
 Two failure modes, not one.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -14,7 +14,7 @@ pattern before cementing a shape. It is deliberate here for one reason: this
 repository is the demonstration, so every rule it ships must be running
 somewhere. Do not copy this choice into a new project — copy the advice.
 
-**Three rules are switched off, each because it is not about this repository.**
+**Four rules are switched off, each because it is not about this repository.**
 `L0.ONE_ENTRYPOINT_PER_FILE` and `L0.PERSISTENCE_STAYS_IN_REPOSITORIES` ship no
 Rust query, because neither concept has a Rust meaning yet and inventing one so
 a coverage table looks full is how a rule starts producing findings nobody
@@ -120,7 +120,7 @@ Dependency manifests are hash-locked. A changed manifest without a matching lock
 
 **Why.** Adding a dependency is a supply-chain decision wearing the costume of a one-line diff, and it is the single easiest thing for an agent to do while solving something else. Forcing the lock to move in the same commit turns the reviewer's attention on at exactly the moment it is worth spending.
 
-**Fix.** If the dependency is intended, run `sf lock --update` in the same commit and say in the message what it buys. If it is incidental, remove it.
+**Fix.** If the dependency is intended, run `sf lock` in the same commit and say in the message what it buys. If it is incidental, remove it.
 
 ### L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE
 
@@ -235,6 +235,16 @@ Every file at the repository root is listed in the root allowlist file.
 **Why.** `NOTES.md`, `PLAN.md`, `SUMMARY.md`, `ANALYSIS.md` at the repository root is the most recognizable signature of agent-authored work, and each one is context that belongs in a plan, a pull request body or a commit message — somewhere with a lifecycle. The allowlist costs one line when a root file is genuinely warranted and blocks the reflex the rest of the time.
 
 **Fix.** Move the content to the plans directory or the pull request description. If the file really belongs at the root, add it to the allowlist in the same commit.
+
+### L4.RULE_PROSE_NAMES_A_REAL_COMMAND
+
+**Every command a rule's prose quotes is one this `sf` accepts**
+
+Every `sf ...` invocation quoted in an enabled rule's statement, why or fix names a subcommand this binary has, with long flags that subcommand accepts.
+
+**Why.** A rule's `fix` is the only documentation an agent reliably reads, and it is read at the one moment somebody is trying to comply. An invocation that never existed sends that reader to a dead end and makes the rule itself look wrong, which is how a guardrail loses the argument it should win. This is not hypothetical: one L3 rule shipped telling people to regenerate evidence with a subcommand that was never implemented, and nothing noticed, because `L4.EVERY_RULE_HAS_A_WHY` checks that a rule id is cited, not that the text around the citation is still true. The same drift arrives from the other direction once rules travel: a rule written against a newer `sf` names a subcommand the binary in this repository does not have yet. The accepted surface is read out of the command-line definition itself, so it cannot become a second list somebody forgets to update.
+
+**Fix.** Correct the invocation where the rule defines it, in the catalog entry or in the `.software-factory/rules` file for a local rule, then run `sf docs` so the generated prose follows. If the command named is the one that ought to exist, that is a change to the tool and the prose is early rather than wrong.
 
 ## L5 — Meta: the guardrail is proven to fire
 

--- a/plans/keep-generated-prose-in-sync.md
+++ b/plans/keep-generated-prose-in-sync.md
@@ -35,5 +35,30 @@ regenerating fails, which is exactly how this was found again. What that does
 not accept. The prose regenerates faithfully; it is the content of the prose
 that was wrong. The exit condition below is unchanged.
 
+**Closed.** `L4.RULE_PROSE_NAMES_A_REAL_COMMAND` reads every invocation of this
+tool that an enabled rule's statement, why or fix quotes, and compares it with
+the clap definition in `src/main.rs`. The accepted surface is derived from the
+command line itself rather than written down, so it cannot become the second
+stale list this plan was already about. Placeholders are exempt on purpose:
+prose describing the *shape* of an invocation is not telling anyone to run it.
+
+It found two live instances the moment it ran.
+`L2.DEPENDENCIES_CHANGE_DELIBERATELY` and `L2.GENERATED_FILES_ARE_LOCKED` both
+told the reader to lock with a flag that `sf lock` has never accepted, which is
+the same defect as the L3 one above and had been shipping for as long. A unit
+test runs the sweep over the whole built-in catalog, including the rules this
+repository switches off: the check reads enabled rules only, because a
+repository is not answerable for prose it never shows anyone, but the catalog
+ships to everybody.
+
+What is still uncovered is prose drift that is not a command. A `why` that has
+quietly stopped describing what its check does reads exactly like one that
+still fits, and no check here can tell the difference. The three candidate
+shapes above stay written down for the day a second kind of drift shows up;
+this closed the one that actually happened, twice.
+
 **Exit condition:** a rule's `fix` naming a command that `sf` does not accept
-fails `sf check`, proven by a mutation fixture that does exactly that.
+fails `sf check`, proven by a mutation fixture that does exactly that. Met:
+`.software-factory/mutations/L4.RULE_PROSE_NAMES_A_REAL_COMMAND` ships a local
+rule whose fix names a subcommand that never existed, and `sf verify` trips the
+rule on it.

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -128,6 +128,9 @@ pub enum CadenceMode {
     MutationCoverage,
     /// No enabled rule is configured so it cannot produce a finding.
     InertRules,
+    /// Every `sf` invocation an enabled rule's prose quotes is one this
+    /// binary accepts.
+    RuleCommands,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -230,6 +233,7 @@ const BUILTIN: &[(&str, &str)] = &[
     ("L4/every-rule-has-a-why.yaml", include_str!("../catalog/L4/every-rule-has-a-why.yaml")),
     ("L4/plan-declares-exit-condition.yaml", include_str!("../catalog/L4/plan-declares-exit-condition.yaml")),
     ("L4/plan-criterion-names-its-check.yaml", include_str!("../catalog/L4/plan-criterion-names-its-check.yaml")),
+    ("L4/rule-prose-names-a-real-command.yaml", include_str!("../catalog/L4/rule-prose-names-a-real-command.yaml")),
     ("L5/every-check-has-a-mutation-test.yaml", include_str!("../catalog/L5/every-check-has-a-mutation-test.yaml")),
     ("L5/no-inert-rule.yaml", include_str!("../catalog/L5/no-inert-rule.yaml")),
     ("L2/factory-config-is-locked.yaml", include_str!("../catalog/L2/factory-config-is-locked.yaml")),

--- a/src/checks/cadence.rs
+++ b/src/checks/cadence.rs
@@ -11,7 +11,7 @@ use crate::policy::{FIXTURES_DIR, Options};
 use crate::scan;
 use anyhow::Result;
 use regex::Regex;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx, mode: CadenceMode) -> Result<Vec<Finding>> {
     match mode {
@@ -23,6 +23,7 @@ pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx, mode: CadenceMode) -> Result<
         CadenceMode::GateCoverage => gate_coverage(rule, ctx),
         CadenceMode::MutationCoverage => mutation_coverage(rule, ctx),
         CadenceMode::InertRules => inert_rules(rule, ctx),
+        CadenceMode::RuleCommands => rule_commands(rule, ctx),
     }
 }
 
@@ -478,4 +479,160 @@ fn gate_coverage(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
         }
     }
     Ok(findings)
+}
+
+/// An `sf` invocation quoted in prose, e.g. `sf seal <gate>`. Only spans that
+/// *open* with the tool's name are invocations; a backtick span that merely
+/// mentions it somewhere in the middle is a sentence.
+const CITED_COMMAND: &str = r"`sf ([^`]+)`";
+
+/// `L4.RULE_PROSE_NAMES_A_REAL_COMMAND`: prose telling the reader to run
+/// something this binary does not have.
+///
+/// The accepted surface comes from the command-line definition itself, so the
+/// check cannot drift from the tool the way the prose just did.
+fn rule_commands(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
+    let accepted = crate::accepted_commands();
+    let cited = Regex::new(CITED_COMMAND)?;
+    let document = ctx.policy.docs.rules_document().to_string();
+    let mut findings = Vec::new();
+    for (id, candidate) in &ctx.catalog.rules {
+        if !ctx.policy.any_instance_enabled(id) {
+            continue;
+        }
+        let prose = [
+            ("statement", &candidate.statement),
+            ("why", &candidate.why),
+            ("fix", &candidate.fix),
+        ];
+        for (field, text) in prose {
+            for hit in cited.captures_iter(text) {
+                let invocation = hit[1].trim();
+                let Some((problem, expected)) = unaccepted(invocation, &accepted) else {
+                    continue;
+                };
+                findings.push(
+                    Finding::new(
+                        &rule.id,
+                        rule.severity,
+                        document.clone(),
+                        format!("dead-command:{id}:{invocation}"),
+                        format!("{id}'s `{field}` says to run `sf {invocation}`, and {problem}"),
+                    )
+                    .expected(expected)
+                    .actual(format!("sf {invocation}")),
+                );
+            }
+        }
+    }
+    Ok(findings)
+}
+
+/// What is wrong with an invocation, and what this binary would have accepted.
+/// `None` means it would run.
+fn unaccepted(
+    invocation: &str,
+    accepted: &BTreeMap<String, BTreeSet<String>>,
+) -> Option<(String, String)> {
+    let mut tokens = invocation.split_whitespace();
+    let name = tokens.next()?;
+    // Nothing here names a subcommand, so there is nothing to be wrong about.
+    // Either prose is describing the *shape* of an invocation (`sf <command>`,
+    // `sf ...`) rather than telling anyone to run it, or a global flag came
+    // first — and deciding which of the tokens after `--root` is its value
+    // would invent findings. Rule prose does not write invocations that way.
+    if name.starts_with('-') || name.starts_with('<') || name.chars().all(|c| c == '.') {
+        return None;
+    }
+    let Some(flags) = accepted.get(name) else {
+        return Some((
+            format!("`{name}` is not a subcommand this `sf` has"),
+            format!("one of: {}", joined(accepted.keys())),
+        ));
+    };
+    // Long flags only. Everything else in an invocation is a value or a
+    // placeholder — `<gate>`, `L1.COMPLEXITY_CEILING`, `origin/main` — and a
+    // rule that guessed at those would produce findings nobody believes.
+    for token in tokens {
+        let flag = token.split('=').next().unwrap_or(token);
+        if !flag.starts_with("--") || flags.contains(flag) {
+            continue;
+        }
+        return Some((
+            format!("`sf {name}` does not accept `{flag}`"),
+            format!("`sf {name}` with one of: {}", joined(flags.iter())),
+        ));
+    }
+    None
+}
+
+fn joined<'a>(names: impl Iterator<Item = &'a String>) -> String {
+    names.cloned().collect::<Vec<_>>().join(", ")
+}
+
+#[cfg(test)]
+mod cited_commands {
+    use super::unaccepted;
+    use crate::catalog::Catalog;
+
+    /// Every invocation the shipped catalog quotes, including the rules this
+    /// repository has switched off. The check itself only reads enabled rules,
+    /// because a repository is not answerable for prose it never shows anyone;
+    /// the catalog is ours, and a dead command in it ships to everybody.
+    #[test]
+    fn the_shipped_catalog_quotes_only_real_commands() {
+        let accepted = crate::accepted_commands();
+        let cited = regex::Regex::new(super::CITED_COMMAND).expect("the pattern compiles");
+        let catalog = Catalog::builtin().expect("the built-in catalog loads");
+        let mut dead = Vec::new();
+        for rule in catalog.rules.values() {
+            for text in [&rule.statement, &rule.why, &rule.fix] {
+                for hit in cited.captures_iter(text) {
+                    let invocation = hit[1].trim();
+                    if let Some((problem, _)) = unaccepted(invocation, &accepted) {
+                        dead.push(format!("{}: `sf {invocation}` — {problem}", rule.id));
+                    }
+                }
+            }
+        }
+        assert!(dead.is_empty(), "catalog prose names commands sf does not accept:\n{dead:#?}");
+    }
+
+    #[test]
+    fn a_real_invocation_is_accepted() {
+        let accepted = crate::accepted_commands();
+        for invocation in [
+            "verify",
+            "seal <gate>",
+            "explain L1.COMPLEXITY_CEILING",
+            "ratchet --months 6",
+            "check --changed origin/main",
+            "check --format=json",
+            "init --language typescript --layer L1,L4,L5",
+            // Prose about the form of an invocation, not an invocation.
+            "...",
+            "<subcommand> --help",
+        ] {
+            assert_eq!(unaccepted(invocation, &accepted), None, "{invocation}");
+        }
+    }
+
+    #[test]
+    fn a_subcommand_that_does_not_exist_is_a_finding() {
+        let accepted = crate::accepted_commands();
+        let (problem, expected) =
+            unaccepted("evidence record", &accepted).expect("`sf evidence` is not a command");
+        assert!(problem.contains("evidence"), "{problem}");
+        assert!(expected.contains("seal"), "the expectation lists the real commands: {expected}");
+    }
+
+    /// The narrower half, and the one that was live in this catalog: a real
+    /// subcommand carrying a flag it never had.
+    #[test]
+    fn a_flag_the_subcommand_does_not_take_is_a_finding() {
+        let accepted = crate::accepted_commands();
+        let (problem, _) =
+            unaccepted("lock --update", &accepted).expect("`sf lock` takes no --update");
+        assert!(problem.contains("--update"), "{problem}");
+    }
 }

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -253,6 +253,15 @@ pub const FIXTURES: &[Fixture] = &[
         )],
     },
     Fixture {
+        rule: "L4.RULE_PROSE_NAMES_A_REAL_COMMAND",
+        policy_extra: "",
+        // The rule is about other rules' prose, so the fixture needs one to be
+        // about: a local rule whose `fix` sends the reader to a subcommand that
+        // never existed. This is the exact drift that produced the rule.
+        extra_rules: "  L4.LOCAL_RULE_WITH_A_DEAD_COMMAND:\n    enabled: true\n",
+        files: &[(".software-factory/rules/local-rule.yaml", RULE_NAMING_A_DEAD_COMMAND)],
+    },
+    Fixture {
         rule: "L3.GATE_COVERS_THE_PLAN",
         policy_extra: "",
         extra_rules: "",
@@ -378,6 +387,25 @@ pub const FIXTURES: &[Fixture] = &[
         files: &[("src/app.py", "print('a repository with a lock that locks nothing')\n")],
     },
 ];
+
+/// A repo-local rule that reads perfectly well and tells you to run something
+/// this binary has never had. Only the prose is wrong, which is what makes it
+/// the mutation: nothing about the check it configures is broken.
+const RULE_NAMING_A_DEAD_COMMAND: &str = "\
+id: L4.LOCAL_RULE_WITH_A_DEAD_COMMAND\n\
+layer: L4\n\
+title: A local rule whose fix names a command that does not exist\n\
+severity: low\n\
+statement: Nothing in this fixture violates this rule; its prose is the mutation.\n\
+why: A rule needs a reason, and this one exists to carry a dead command in its fix.\n\
+fix: Regenerate the manifest with `sf evidence record`, then commit it.\n\
+ratchet: allowlist\n\
+check:\n  kind: text_pattern\n\
+defaults:\n  \
+scope: [\"src/**\"]\n  \
+forbidden:\n    \
+- regex: \"a shape this fixture never contains\"\n      \
+message: \"Unreachable: this rule is here for its prose, not its pattern.\"\n";
 
 /// A believable CI file that tests and lints and hunts none of the hazards.
 const CI_WITHOUT_HAZARD_TOOLS: &str = "name: ci\non: [push]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: pytest\n      - run: npm test\n      - run: go test ./...\n      - run: cargo test\n";

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use finding::{EXIT_BOOTSTRAP, EXIT_CONFIG, EXIT_OK};
 use policy::{Policy, RULES_DIR};
 use ratchet::Ratchet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -145,6 +146,32 @@ enum Cmd {
         #[arg(long, env = "SF_ALLOW_COMMANDS")]
         allow_commands: bool,
     },
+}
+
+/// What this build of `sf` actually accepts: subcommand name -> the long
+/// flags it takes, with the global ones folded in.
+///
+/// Read out of the clap definition above rather than written down anywhere,
+/// because a second list of commands is a list that goes stale — which is the
+/// defect `L4.RULE_PROSE_NAMES_A_REAL_COMMAND` exists to catch in prose.
+pub fn accepted_commands() -> BTreeMap<String, BTreeSet<String>> {
+    use clap::CommandFactory;
+    let cli = Cli::command();
+    // clap adds these two on build, and nothing here builds the command.
+    let mut global = long_flags(&cli);
+    global.insert("--help".to_string());
+    global.insert("--version".to_string());
+    cli.get_subcommands()
+        .map(|sub| {
+            let mut flags = long_flags(sub);
+            flags.extend(global.iter().cloned());
+            (sub.get_name().to_string(), flags)
+        })
+        .collect()
+}
+
+fn long_flags(command: &clap::Command) -> BTreeSet<String> {
+    command.get_arguments().filter_map(|arg| arg.get_long()).map(|l| format!("--{l}")).collect()
 }
 
 struct Loaded {


### PR DESCRIPTION
Closes the exit condition of [`plans/keep-generated-prose-in-sync.md`](plans/keep-generated-prose-in-sync.md): a rule whose `fix` names a command `sf` does not accept now fails `sf check`, proven by a mutation fixture that does exactly that.

## The hole

`docs/rules.md` is generated from the catalog and then hand-edited, so when `L3.GATE_HAS_FRESH_EVIDENCE` shipped telling people to run `sf evidence record`, nothing noticed. `L4.EVERY_RULE_HAS_A_WHY` checks that a rule id is cited, not that the text around the citation is still true. `L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE` later closed half of it by regenerating the document on every check, but the prose regenerated faithfully. It was the content of the prose that was wrong.

## The rule

`L4.RULE_PROSE_NAMES_A_REAL_COMMAND` reads every `sf ...` an enabled rule's statement, why or fix quotes and compares it with the clap definition in `src/main.rs`. The accepted surface is derived from the command line itself rather than written down, so it cannot become the second stale list this was already about.

Subcommands and long flags are checked. Placeholders (`sf <command>`, `sf ...`) are exempt on purpose: prose describing the shape of an invocation is not telling anyone to run it, and a rule that guessed at values would produce findings nobody believes.

## What it found on its first run

| Rule | Prose said | `sf lock` actually takes |
|---|---|---|
| `L2.DEPENDENCIES_CHANGE_DELIBERATELY` | `sf lock --update` | no flags |
| `L2.GENERATED_FILES_ARE_LOCKED` | `sf lock --update` | no flags |

The prose is what moved. `cmd_lock` already rewrites every lock from what is on disk, so a no-op `--update` would exist only to make the sentence true.

## Coverage, and the line drawn

The check reads enabled rules, because a repository is not answerable for prose it never shows anyone. A unit test runs the same sweep over the whole built-in catalog, including the four rules switched off here, because that catalog ships to everybody.

Still uncovered, and written down in the plan rather than implied: prose drift that is not a command. A `why` that has quietly stopped describing what its check does reads exactly like one that still fits.

## Proof

- `sf verify --allow-commands`: 29/29 enabled rules proven to fire. The fixture is a repo-local rule whose `fix` names a subcommand that never existed, so only the prose is wrong, which is what makes it the mutation.
- `sf check --allow-commands --changed origin/main`: 29 rules, no findings.
- `cargo test`: 9/9, four of them new.
- `cargo clippy --all-targets -- -D warnings -D dead_code`: clean.
- Adopter path: fresh repo, `sf init --language python --layer L1,L4,L5`, rule ships with its fixture, 12/12 proven.

## Counts corrected while they moved

README said 27 rules and 23 enabled; it is 33 and 29. `docs/rules.md` said three rules are switched off here and then listed four.