### PR TITLE
fix(ratchet): a re-seed recomputed the deadline, not just the keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,15 @@ Keys are derived from content, not line numbers, so moving code around does not
 silently un-freeze the ratchet — and adding a key by hand to silence a new
 violation is a visible line in a reviewed diff.
 
+Re-seeding recomputes the frozen keys, never the deadline: a date already
+accepted survives, and a newly frozen violation does not reset the clock on the
+debt beside it. This matters because `sf ratchet` is part of the prescribed
+order after any guardrail change — a run that stamped today + `N` months on
+every entry would push every deadline out on every unrelated change, which
+`L2.POLICY_ONLY_TIGHTENS` then rejects. Renewing a date that has genuinely
+expired is a deliberate edit to the file, with the reasoning in the pull
+request, which is the conversation the date exists to force.
+
 ---
 
 ## Commands

--- a/src/init.rs
+++ b/src/init.rs
@@ -230,6 +230,9 @@ pub fn refresh_fixtures(root: &Path, catalog: &Catalog) -> Result<Vec<String>> {
 /// Freeze today's violations so the rules can be adopted by a repository that
 /// already breaks them. New violations still fail from the first run.
 pub fn seed_ratchet(root: &Path, catalog: &Catalog, months: i64) -> Result<(Ratchet, usize)> {
+    // The ratchet on disk is the only record of when this debt was accepted.
+    // Re-seeding recomputes the frozen keys, never the deadline.
+    let previous = Ratchet::load(root)?;
     let policy = Policy::load(root)?;
     let files = scan::walk(root, &policy)?;
     let empty = Ratchet::default();
@@ -259,7 +262,7 @@ pub fn seed_ratchet(root: &Path, catalog: &Catalog, months: i64) -> Result<(Ratc
             .map(|f| f.key)
             .collect();
         total += keys.len();
-        ratchet.seed(id, keys, &review_by);
+        ratchet.seed(id, keys, &review_by, previous.rules.get(id.as_str()));
     }
     ratchet.save(root)?;
     Ok((ratchet, total))

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -76,8 +76,24 @@ impl Ratchet {
         (live, frozen)
     }
 
-    /// Replace a rule's frozen set with exactly today's violations.
-    pub fn seed(&mut self, rule: &str, keys: BTreeSet<String>, review_by: &str) {
+    /// Replace a rule's frozen set with exactly today's violations, carrying
+    /// `previous`'s date and note forward.
+    ///
+    /// The date only ever moves closer. A re-seed is not a way to buy another
+    /// six months on debt already counted: `sf ratchet` is part of the
+    /// prescribed order after any guardrail change, so a run that stamped
+    /// today + N months on untouched entries would push every date out on
+    /// every unrelated change — which `L2.POLICY_ONLY_TIGHTENS` correctly
+    /// rejects, leaving the repository unable to follow its own instructions.
+    /// Renewing a date that has genuinely expired is a human's edit, with the
+    /// reasoning in the pull request.
+    pub fn seed(
+        &mut self,
+        rule: &str,
+        keys: BTreeSet<String>,
+        review_by: &str,
+        previous: Option<&RuleRatchet>,
+    ) {
         if keys.is_empty() {
             self.rules.remove(rule);
             return;
@@ -85,5 +101,62 @@ impl Ratchet {
         let entry = self.rules.entry(rule.to_string()).or_default();
         entry.allow = keys;
         entry.review_by = review_by.to_string();
+        let Some(previous) = previous else { return };
+        // ISO dates order lexicographically, which is the same comparison
+        // `L2.NO_PERMANENT_EXCEPTION` makes against today.
+        if !previous.review_by.is_empty() && previous.review_by < entry.review_by {
+            entry.review_by = previous.review_by.clone();
+        }
+        entry.note = previous.note.clone();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frozen(keys: &[&str]) -> BTreeSet<String> {
+        keys.iter().map(|k| k.to_string()).collect()
+    }
+
+    fn seeded(review_by: &str, note: Option<&str>, keys: &[&str]) -> RuleRatchet {
+        RuleRatchet {
+            review_by: review_by.to_string(),
+            note: note.map(|n| n.to_string()),
+            allow: frozen(keys),
+        }
+    }
+
+    #[test]
+    fn a_re_seed_never_pushes_a_review_date_out() {
+        let previous = seeded("2027-02-18", Some("measured, not guessed"), &["rust"]);
+        let mut ratchet = Ratchet::default();
+        ratchet.seed("L6.PERF", frozen(&["rust"]), "2027-02-25", Some(&previous));
+        let entry = &ratchet.rules["L6.PERF"];
+        assert_eq!(entry.review_by, "2027-02-18");
+        assert_eq!(entry.note.as_deref(), Some("measured, not guessed"));
+    }
+
+    #[test]
+    fn a_new_violation_does_not_reset_the_clock_on_the_old_debt() {
+        let previous = seeded("2027-02-18", None, &["rust"]);
+        let mut ratchet = Ratchet::default();
+        ratchet.seed("L6.PERF", frozen(&["rust", "python"]), "2027-08-25", Some(&previous));
+        assert_eq!(ratchet.rules["L6.PERF"].review_by, "2027-02-18");
+    }
+
+    #[test]
+    fn a_rule_the_ratchet_has_never_seen_takes_the_new_date() {
+        let mut ratchet = Ratchet::default();
+        ratchet.seed("L6.PERF", frozen(&["rust"]), "2027-08-25", None);
+        assert_eq!(ratchet.rules["L6.PERF"].review_by, "2027-08-25");
+    }
+
+    #[test]
+    fn a_rule_with_nothing_left_to_freeze_leaves_the_file() {
+        let previous = seeded("2027-02-18", None, &["rust"]);
+        let mut ratchet = Ratchet::default();
+        ratchet.seed("L6.PERF", BTreeSet::new(), "2027-08-25", Some(&previous));
+        assert!(ratchet.rules.is_empty());
     }
 }


### PR DESCRIPTION
## What happened

`sf ratchet` built its output from `Ratchet::default()` and stamped `review_by = today + N months` on every entry it wrote — including entries whose frozen set had not changed. Hand-written `note` fields were dropped the same way.

That is not cosmetic. `sf ratchet` is part of the prescribed order after any guardrail change (`AGENTS.md`: fixtures, docs, ratchet, lock), so a week after seeding, a change about something else picks up:

```
✗ critical L2.POLICY_ONLY_TIGHTENS
  .software-factory/ratchet.yaml — L6.PERFORMANCE_REGRESSION_IS_GUARDED had its review date pushed out
    expected 2027-02-18
    actual   2027-02-25
```

`L2.POLICY_ONLY_TIGHTENS` is right to fail there — a pushed-out deadline is exactly the quiet loosening it exists to catch. The bug is that the repository could not follow its own documented order without tripping its own rule. Three pull requests here (#7, #8, #9) failed on that single line, in three unrelated changes, before the cause was found.

## The change

`Ratchet::seed` now takes the previous entry and carries its date and note forward, keeping whichever date is **earlier**. Two properties follow:

- a re-seed of an unchanged frozen set is a no-op;
- a newly frozen violation cannot reset the clock on the debt beside it.

The date only ever moves closer. Renewing one that has genuinely expired stays a deliberate edit to the file with the reasoning in the pull request — which is the conversation the date exists to force, and `L2.NO_PERMANENT_EXCEPTION` still fails the build until someone has it.

## Proof

Four unit tests in `src/ratchet.rs`. They are not blind — with the inheritance removed, the two that matter accuse by name:

```
test ratchet::tests::a_re_seed_never_pushes_a_review_date_out ... FAILED
test ratchet::tests::a_new_violation_does_not_reset_the_clock_on_the_old_debt ... FAILED
test result: FAILED. 11 passed; 2 failed
```

Restored, and end to end in this repository: `sf ratchet --months 6` now leaves `.software-factory/ratchet.yaml` byte-identical, where before it moved the date a week.

Full contract locally: `cargo build --release --locked`, `sf verify --allow-commands` (29/29 rules proven to fire), `sf check --allow-commands --changed upstream/main` (29 rules, no findings), `cargo test` (13 passed), `cargo clippy --all-targets -- -D warnings -D dead_code` clean.

No rule was widened and no policy was touched.