### PR TITLE
fix(L1): the grain rules cover Ruby

### DIFF
--- a/.software-factory/mutations/L1.NO_BLANKET_SUPPRESSION/src/legacy.rb
+++ b/.software-factory/mutations/L1.NO_BLANKET_SUPPRESSION/src/legacy.rb
@@ -1,0 +1,6 @@
+require "json" # rubocop:disable all
+
+# Parsed by hand upstream; TICKET-88 removes the branch.
+def parse(raw) # rubocop:disable Metrics/AbcSize
+  JSON.parse(raw)
+end

--- a/.software-factory/mutations/L1.NO_UNTYPED_ESCAPE_HATCH/sig/payload.rbs
+++ b/.software-factory/mutations/L1.NO_UNTYPED_ESCAPE_HATCH/sig/payload.rbs
@@ -1,0 +1,3 @@
+class Payload
+  def handle: (untyped event) -> untyped
+end

--- a/.software-factory/mutations/L1.NO_UNTYPED_ESCAPE_HATCH/src/payload.rb
+++ b/.software-factory/mutations/L1.NO_UNTYPED_ESCAPE_HATCH/src/payload.rb
@@ -1,0 +1,6 @@
+# typed: strict
+
+sig { params(event: T.untyped).returns(T.untyped) }
+def handle(event)
+  event
+end

--- a/.software-factory/mutations/L4.CLAIM_CITES_ITS_EVIDENCE/.software-factory/policy.yaml
+++ b/.software-factory/mutations/L4.CLAIM_CITES_ITS_EVIDENCE/.software-factory/policy.yaml
@@ -2,7 +2,7 @@
 version: 1
 project:
   name: mutation-L4.CLAIM_CITES_ITS_EVIDENCE
-  languages: [python, typescript, go, rust]
+  languages: [python, typescript, go, rust, ruby]
 docs:
   scan: ["docs/**/*.md"]
 gates: {}

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ git config core.hooksPath .githooks
 ```
 
 Use `--language` for what you actually have: `python`, `typescript`, `go`,
-`rust`, or several comma-separated. `--layer L1,L4,L5,L6` is the honest day-one
+`rust`, `ruby`, or several comma-separated. `--layer L1,L4,L5,L6` is the honest day-one
 set — code quality, documentation cadence, the self-proving layer, and the
 security tooling. You get the generic rules; the structural ones stay off until
 you run the interview or write them yourself.
@@ -300,14 +300,14 @@ the tool — it is the guarantee that the tool is *still wired in*. So a rule
 names a concern, and the check asserts that something covering it actually runs
 in your CI or task runner.
 
-| Concern | Python | TypeScript | Go | Rust |
-|---|---|---|---|---|
-| Dependency vulnerabilities | pip-audit | npm audit, osv-scanner | govulncheck | cargo audit |
-| Committed secrets | gitleaks, detect-secrets, trufflehog (language-independent) | ← | ← | ← |
-| Insecure patterns | bandit, semgrep | semgrep, eslint-plugin-security | gosec | clippy, cargo-geiger |
-| Dead code | vulture | knip, ts-prune | staticcheck | dead_code, cargo udeps |
-| Data races | — | — | go test -race | ThreadSanitizer, loom |
-| Performance regression | pytest-benchmark | vitest bench | go test -bench | criterion |
+| Concern | Python | TypeScript | Go | Rust | Ruby |
+|---|---|---|---|---|---|
+| Dependency vulnerabilities | pip-audit | npm audit, osv-scanner | govulncheck | cargo audit | bundler-audit |
+| Committed secrets | gitleaks, detect-secrets, trufflehog (language-independent) | ← | ← | ← | ← |
+| Insecure patterns | bandit, semgrep | semgrep, eslint-plugin-security | gosec | clippy, cargo-geiger | brakeman, semgrep |
+| Dead code | vulture | knip, ts-prune | staticcheck | dead_code, cargo udeps | — |
+| Data races | — | — | go test -race | ThreadSanitizer, loom | — |
+| Performance regression | pytest-benchmark | vitest bench | go test -bench | criterion | — |
 
 `sf init` writes these steps into the generated workflow for the languages you
 selected. A concern with no listed tool for a language is not a violation —
@@ -484,7 +484,7 @@ check:
   run: "make export-openapi && git diff --exit-code -- contracts/"
 ```
 
-Languages today: **Python, TypeScript/TSX, Go, Rust.**
+Languages today: **Python, TypeScript/TSX, Go, Rust, Ruby.**
 
 `sf verify` requires every language a rule declares to be shown tripping it,
 otherwise three broken queries hide behind one that works.

--- a/catalog/L1/no-blanket-suppression.yaml
+++ b/catalog/L1/no-blanket-suppression.yaml
@@ -24,6 +24,7 @@ defaults:
     - "**/*.tsx"
     - "**/*.go"
     - "**/*.rs"
+    - "**/*.rb"
   # Every pattern is `regex` (the shape that is not acceptable) plus an
   # optional `unless` (the shape that is). Two positive patterns rather than
   # one negative lookahead: it keeps the rules readable and portable to any
@@ -46,3 +47,16 @@ defaults:
     - regex: "#\\[allow\\("
       unless: "#\\[allow\\([^)]*\\)\\]\\s*//\\s*\\S"
       message: "`#[allow(...)]` with no trailing `// reason` hides a lint forever. Say why on the same line."
+    # Cop names are department-qualified and capitalised (`Metrics/AbcSize`),
+    # and `all` is not — so `[A-Z]` is what separates naming a cop from
+    # turning the whole line off, without a negative lookahead the regex
+    # engine here does not have.
+    #
+    # Sorbet's `# typed: false` sigil is deliberately not here. It suppresses
+    # a whole file, which is worse, but a gradual Sorbet adoption is *made* of
+    # those sigils and a rule that fires on every one of them on day one is a
+    # rule a Ruby team switches off. The escape hatch it exists to permit,
+    # `T.untyped`, is banned by L1.NO_UNTYPED_ESCAPE_HATCH instead.
+    - regex: "#\\s*(rubocop|standard):disable"
+      unless: "#\\s*(rubocop|standard):disable\\s+[A-Z]"
+      message: "`# rubocop:disable all` turns off every cop on the line. Name the one you mean: `# rubocop:disable Metrics/AbcSize`, with the reason on the line above."

--- a/catalog/L1/no-untyped-escape-hatch.yaml
+++ b/catalog/L1/no-untyped-escape-hatch.yaml
@@ -30,12 +30,19 @@ defaults:
     - "**/*.tsx"
     - "**/*.go"
     - "**/*.rs"
+    - "**/*.rb"
+    # Type-only files, where `untyped` is the escape hatch written down
+    # deliberately rather than reached for in a hurry. It is the same
+    # decision either way, so it is checked in the same place.
+    - "**/*.rbs"
   exclude:
     - "**/*.test.ts"
     - "**/*.spec.ts"
     - "**/tests/**"
     - "**/*_test.go"
     - "**/tests/**"
+    - "**/spec/**"
+    - "**/*_spec.rb"
   forbidden:
     - regex: "^\\s*from\\s+typing\\s+import\\s+(.*,\\s*)?Any\\b"
       message: "Banning the *import* is what makes this stick: it kills `dict[str, Any]`, `-> Any` and bare `x: Any` in one rule. Use a TypedDict/dataclass for a known shape, a TypeVar for passthrough, or your JSON value type at the boundary."
@@ -45,3 +52,11 @@ defaults:
       message: "`interface{}` defers the decision to runtime. Define the interface you actually need, or use a type parameter."
     - regex: "\\.unwrap\\(\\)"
       message: "`.unwrap()` converts a case you have not handled into a crash with no message. Use `?` to propagate, or `.context(\"what was being attempted\")` so the failure says something."
+    # Sorbet writes it `T.untyped`, RBS writes it `untyped`, and both mean
+    # exactly what `Any` means: every call downstream stops being checked.
+    # The delimiter excludes `-` as well as word characters, because `\b`
+    # alone treats a hyphen as a boundary and fires on any path containing
+    # `no-untyped-escape-hatch` — which is how this repository's own source
+    # caught the first draft of this pattern.
+    - regex: "(^|[^\\w-])untyped([^\\w-]|$)"
+      message: "`T.untyped` (and `untyped` in an .rbs) opts the whole call chain out of type checking. Use a `T::Struct` or an interface for a known shape, `T.type_parameter` for genuine passthrough, or `T.nilable`/`T.any` where the shape is a small union."

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -128,7 +128,18 @@ pub const FIXTURES: &[Fixture] = &[
         rule: "L1.NO_BLANKET_SUPPRESSION",
         policy_extra: "",
         extra_rules: "",
-        files: &[("src/legacy.py", "import os  # noqa\n")],
+        files: &[
+            ("src/legacy.py", "import os  # noqa\n"),
+            // The violation and the accepted form together: `all` turns the
+            // line off, a named cop does not. If the `unless` ever stops
+            // matching, the second line starts producing a finding here,
+            // which is the only way a fixture can be about a rule staying
+            // quiet.
+            (
+                "src/legacy.rb",
+                "require \"json\" # rubocop:disable all\n\n# Parsed by hand upstream; TICKET-88 removes the branch.\ndef parse(raw) # rubocop:disable Metrics/AbcSize\n  JSON.parse(raw)\nend\n",
+            ),
+        ],
     },
     Fixture {
         rule: "L1.SKIPPED_TESTS_STATE_A_REASON",
@@ -165,10 +176,17 @@ pub const FIXTURES: &[Fixture] = &[
         rule: "L1.NO_UNTYPED_ESCAPE_HATCH",
         policy_extra: "",
         extra_rules: "",
-        files: &[(
-            "src/payload.py",
-            "from typing import Any\n\n\ndef handle(event: dict) -> Any:\n    return event\n",
-        )],
+        files: &[
+            (
+                "src/payload.py",
+                "from typing import Any\n\n\ndef handle(event: dict) -> Any:\n    return event\n",
+            ),
+            (
+                "src/payload.rb",
+                "# typed: strict\n\nsig { params(event: T.untyped).returns(T.untyped) }\ndef handle(event)\n  event\nend\n",
+            ),
+            ("sig/payload.rbs", "class Payload\n  def handle: (untyped event) -> untyped\nend\n"),
+        ],
     },
     Fixture {
         rule: "L2.GENERATED_FILES_ARE_LOCKED",

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,7 +62,7 @@ enum Cmd {
         /// Project name recorded in the policy.
         #[arg(long)]
         name: Option<String>,
-        /// Languages to parse: python, typescript, go.
+        /// Languages to parse: python, typescript, go, rust, ruby.
         #[arg(long, value_delimiter = ',', default_values_t = ["python".to_string(), "typescript".to_string(), "go".to_string()])]
         language: Vec<String>,
         /// Layers to enable. L1, L4 and L5 are the honest day-one set: L0


### PR DESCRIPTION
Follow-up to #7 and #9, which are both right and together left a hole.

## What was broken

`sf init --language ruby --layer L1,L4,L5` was red on its first run, on main:

```
✗ high L5.NO_INERT_RULE
  L1.NO_BLANKET_SUPPRESSION is enabled but cannot produce a finding — scope matches no file in this repository
  L1.NO_UNTYPED_ESCAPE_HATCH is enabled but cannot produce a finding — scope matches no file in this repository
```

`sf` parses Ruby, but those two rules still scoped `**/*.py .ts .tsx .go .rs`. The rule was telling the truth and the only way out was switching rules off.

## Suppressions

`# rubocop:disable all` turns off every cop on the line; `# rubocop:disable Metrics/AbcSize` names the one it means. Cop names are department-qualified and capitalised and `all` is not, so `[A-Z]` in the `unless` separates them without the negative lookahead this regex engine does not have. Standard's `# standard:disable` has the same shape and is covered by the same pattern.

Sorbet's `# typed: false` sigil is deliberately **not** here. It suppresses a whole file, which is worse, but a gradual Sorbet adoption is made of those sigils and a rule that fires on every one of them on day one is a rule a Ruby team switches off. The escape hatch it exists to permit is banned below instead.

## The escape hatch

Ruby's form is exact, not approximate: Sorbet writes `T.untyped`, RBS writes `untyped`, and both mean what `Any` means. `**/*.rbs` joins the scope, because a type-only file is where that decision gets written down deliberately, and `spec/` joins the exclusions alongside the other languages' test directories.

The first draft of the pattern was `\buntyped\b`, and this repository's own `sf check` caught it: a hyphen is a word boundary, so it fired on the `include_str!` line naming `no-untyped-escape-hatch.yaml`. The delimiter now excludes `-` as well as word characters.

## Proof

- `sf verify --allow-commands`: 30/30. Both fixtures carry the violating form next to the accepted one (`# rubocop:disable Metrics/AbcSize` stays quiet, a named cop is not a blanket), so the `unless` staying correct is part of what the mutation proves. Findings land in `src/legacy.rb`, `src/payload.rb` and `sig/payload.rbs`.
- A fresh Ruby repository: `sf init --language ruby --layer L1,L4,L5` no longer reports an inert rule, and a file carrying `# rubocop:disable all` and `sig { params(x: T.untyped) }` now produces two findings that name the alternative.
- `sf check --allow-commands --changed origin/main`: 30 rules, no findings. `cargo test` 17/17, clippy clean.

## Claims corrected

README's `--language` list, the L6 hazard table (which had no Ruby column after #8) and "Languages today", plus the `--language` help in `src/main.rs`, which had been stale since Rust landed.

## Still open from the review of #7 through #9

- `untested_languages` in `verify.rs` covers only Shape and Nested, so per-language complexity is proven by nothing: delete `pricing.rb` from the fixture and `sf verify` still passes. Rust, TS and Go were never proven either.
- `sf init` seeds `.allowed-root-files` from root *files* while `L4.ROOT_FILES_ARE_DECLARED` also checks root *directories*, and that rule is `ratchet: none`. Every fresh `sf init` is red on `src`, `docs`, `plans`, `.github`. Separate PR, it is not a Ruby problem.