### PR TITLE
fix(init): the first `sf check` after `sf init` failed on files `sf init` wrote

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -59,6 +59,7 @@ pub fn run(root: &Path, catalog: &Catalog, opts: &InitOptions) -> Result<Vec<Str
     )?;
     write_automation(root, &mut written)?;
     write_fixtures(root, &selected, &mut written)?;
+    write_root_allowlist(root, &selected, &mut written)?;
     Ok(written)
 }
 
@@ -125,11 +126,23 @@ fn write_cadence_files(
     selected: &[&crate::catalog::Rule],
     written: &mut Vec<String>,
 ) -> Result<()> {
-    if selected.iter().any(|r| r.id == "L4.ROOT_FILES_ARE_DECLARED") {
-        write_if_absent(root, ".allowed-root-files", &root_allowlist(root)?, written)?;
-    }
     if selected.iter().any(|r| r.id == "L4.PLAN_DECLARES_EXIT_CONDITION") {
         write_if_absent(root, "plans/next-steps.md", NEXT_STEPS, written)?;
+    }
+    Ok(())
+}
+
+/// Seeded last, because most of what lands at the root is this command's own
+/// scaffolding: the workflow, the hook, the plans directory, the fixtures.
+/// Written before they exist, the allowlist omits them and the first
+/// `sf check` after `sf init` fails on files `sf init` wrote.
+fn write_root_allowlist(
+    root: &Path,
+    selected: &[&crate::catalog::Rule],
+    written: &mut Vec<String>,
+) -> Result<()> {
+    if selected.iter().any(|r| r.id == "L4.ROOT_FILES_ARE_DECLARED") {
+        write_if_absent(root, ".allowed-root-files", &root_allowlist(root)?, written)?;
     }
     Ok(())
 }
@@ -460,16 +473,21 @@ fn root_allowlist(root: &Path) -> Result<String> {
         gates: Default::default(),
         docs: Default::default(),
     };
-    let mut names: Vec<String> = scan::walk(root, &policy)?
+    // Collapsed to the first path segment, which is what
+    // `L4.ROOT_FILES_ARE_DECLARED` counts: a root directory is a root entry
+    // there, so a seeder that emitted only loose files disagreed with the
+    // check it was seeding and every fresh install began red.
+    let names: BTreeSet<String> = scan::walk(root, &policy)?
         .into_iter()
-        .filter(|f| !f.rel.contains('/'))
-        .map(|f| f.rel)
+        .map(|f| match f.rel.split_once('/') {
+            Some((first, _)) => first.to_string(),
+            None => f.rel,
+        })
         .collect();
-    names.sort();
     Ok(format!(
         "# Files allowed at the repository root. Adding a line here is the\n\
          # deliberate act; NOTES.md appearing without one is the reflex.\n{}\n",
-        names.join("\n")
+        names.into_iter().collect::<Vec<_>>().join("\n")
     ))
 }
 
@@ -635,3 +653,90 @@ set -eu\n\n\
 # meaningless, and it is the cheaper failure to discover.\n\
 sf verify\n\
 sf check\n";
+
+/// `sf init` installs the rules and then has to survive them. Nothing else in
+/// the suite runs the generator and then runs a check over its output, which
+/// is how the seeder and `L4.ROOT_FILES_ARE_DECLARED` drifted apart: the check
+/// learned that a root directory is a root entry, the seeder kept emitting
+/// loose files only, and every fresh install failed its first `sf check` on
+/// `.github`, `.githooks`, `docs` and `plans` — all four written by `sf init`.
+#[cfg(test)]
+mod conformance {
+    use super::*;
+
+    struct Scratch(std::path::PathBuf);
+
+    impl Scratch {
+        fn new(tag: &str) -> Scratch {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock is before the epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("sf-{tag}-{}-{nanos}", std::process::id()));
+            std::fs::create_dir_all(&path).expect("scratch directory");
+            Scratch(path)
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn findings_for(root: &Path, id: &str) -> Vec<crate::finding::Finding> {
+        let catalog = Catalog::builtin().expect("builtin catalog");
+        let policy = Policy::load(root).expect("generated policy loads");
+        let files = scan::walk(root, &policy).expect("walk");
+        let ratchet = Ratchet::default();
+        let rule = catalog.get(id).expect("rule is in the catalog");
+        let ctx = Ctx {
+            root,
+            policy: &policy,
+            catalog: &catalog,
+            files: &files,
+            ratchet: &ratchet,
+            changed: None,
+            base: None,
+            today: clock::today(),
+            allow_commands: false,
+        };
+        checks::run_one(rule, &ctx).expect("check runs")
+    }
+
+    #[test]
+    fn a_fresh_install_declares_every_root_entry_it_created() {
+        let scratch = Scratch::new("init");
+        let root = scratch.0.as_path();
+        std::fs::write(root.join("Gemfile"), "source \"https://rubygems.org\"\n").expect("Gemfile");
+        std::fs::create_dir_all(root.join("app")).expect("app");
+        std::fs::write(root.join("app/order.rb"), "class Order\nend\n").expect("order.rb");
+
+        let catalog = Catalog::builtin().expect("builtin catalog");
+        init_for_test(root, &catalog);
+
+        let findings = findings_for(root, "L4.ROOT_FILES_ARE_DECLARED");
+        assert!(
+            findings.is_empty(),
+            "sf init left its own scaffolding undeclared: {:?}",
+            findings.iter().map(|f| f.key.clone()).collect::<Vec<_>>()
+        );
+    }
+
+    fn init_for_test(root: &Path, catalog: &Catalog) {
+        run(
+            root,
+            catalog,
+            &InitOptions {
+                name: "probe".to_string(),
+                languages: vec!["ruby".to_string()],
+                layers: vec!["L4".to_string()],
+                force: false,
+                plan: None,
+                answers: None,
+                rules_document: None,
+            },
+        )
+        .expect("sf init succeeds");
+    }
+}


### PR DESCRIPTION
## What I was doing

After #16 landed I went looking for other places the Ruby adapter left a hole, by running the thing rather than reading it:

```sh
sf init --language ruby --layer L1,L4,L5
sf verify   # 13/13 rules proven to fire
sf check    # 7 findings across 1 rules
```

The Ruby coverage is fine. The generator is not.

```
.githooks — `.githooks` is at the repository root but not declared
.github — `.github` is at the repository root but not declared
.software-factory — `.software-factory` is at the repository root but not declared
docs — `docs` is at the repository root but not declared
plans — `plans` is at the repository root but not declared
```

Five of the seven are directories `sf init` had created seconds earlier. This is not Ruby-specific — it is every fresh install of any language, as soon as `L4.ROOT_FILES_ARE_DECLARED` is in the selected layers.

## Root cause

Two functions disagreed about what a root entry is.

`root_files` in `src/checks/cadence.rs` folds every walked path to its first segment, so a root *directory* is a root entry. The comment there argues for it explicitly, and it is the right call — a new `notes/` or `scratch/` at the root is the same smell as a new `NOTES.md`.

`root_allowlist` in `src/init.rs` filtered `!f.rel.contains('/')` — loose files only. It never emitted a directory. When the check was widened, the seeder was not, and every install since has begun red.

Second, smaller, and independently sufficient: the allowlist was seeded from `write_cadence_files`, which runs before the workflow, the hook and the fixtures are written. Even folded correctly it could not have mentioned `.github` or `.githooks`, because at that moment they did not exist.

## The change

- `root_allowlist` folds to the first path segment, the same fold the check performs.
- The seeding moved to the end of `init::run`, after all scaffolding exists.

## Proof

A regression test that runs the generator and then runs the check over its output — which nothing in the suite did before, and is precisely how these two drifted apart without anybody being careless.

It is not blind. Each half of the fix reverted independently, and the test accuses each by name with the exact entries at fault:

```
# seeder emits loose files only
sf init left its own scaffolding undeclared: [".githooks", ".github", ".software-factory", "app", "docs", "plans"]

# allowlist seeded before the scaffolding
sf init left its own scaffolding undeclared: [".githooks", ".github"]
```

End to end on a fresh Ruby repository, after the fix:

```
$ cat .allowed-root-files
.githooks
.github
.software-factory
Gemfile
app
docs
plans
spec
$ sf verify   -> 13/13 enabled rules proven to fire
$ sf check    -> 13 rules, no findings
```

This repository: `cargo build --release --locked`, `sf verify --allow-commands` (30/30), `sf check --allow-commands --changed upstream/main` clean, `cargo test` (18 passed), `cargo clippy --all-targets -- -D warnings -D dead_code` clean.

## One thing I did not do

There is no rule saying "the generator's output passes the checks it installs". This bug lived in exactly that gap, and the test I added closes it for one rule only. An `L5` rule that scaffolds into a temp root and runs the selected checks over it would close the class — but that is a design call about the guardrail, so it belongs in its own pull request with its own argument, not smuggled into this one.