### PR TITLE
fix(L1): scope text_pattern forbidden entries per language

### DIFF
--- a/.software-factory/mutations/L1.NO_UNTYPED_ESCAPE_HATCH/src/handler.go
+++ b/.software-factory/mutations/L1.NO_UNTYPED_ESCAPE_HATCH/src/handler.go
@@ -1,0 +1,5 @@
+package payload
+
+func Handle(event interface{}) interface{} {
+	return event
+}

--- a/.software-factory/mutations/L1.NO_UNTYPED_ESCAPE_HATCH/src/handler.rs
+++ b/.software-factory/mutations/L1.NO_UNTYPED_ESCAPE_HATCH/src/handler.rs
@@ -1,0 +1,3 @@
+fn parse(raw: &str) -> i64 {
+    raw.parse::<i64>().unwrap()
+}

--- a/.software-factory/mutations/L1.NO_UNTYPED_ESCAPE_HATCH/src/handler.ts
+++ b/.software-factory/mutations/L1.NO_UNTYPED_ESCAPE_HATCH/src/handler.ts
@@ -1,0 +1,3 @@
+function handle(event: any): any {
+  return event;
+}

--- a/catalog/L1/no-untyped-escape-hatch.yaml
+++ b/catalog/L1/no-untyped-escape-hatch.yaml
@@ -45,12 +45,21 @@ defaults:
     - "**/*_spec.rb"
   forbidden:
     - regex: "^\\s*from\\s+typing\\s+import\\s+(.*,\\s*)?Any\\b"
+      scope: ["**/*.py"]
       message: "Banning the *import* is what makes this stick: it kills `dict[str, Any]`, `-> Any` and bare `x: Any` in one rule. Use a TypedDict/dataclass for a known shape, a TypeVar for passthrough, or your JSON value type at the boundary."
+    # TypeScript's `any`. Scoped so it cannot also read Ruby's `:any?`
+    # symbol — `delegate :any?, :empty?, to: :thing` is idiomatic Ruby, and
+    # `:\s*any\b` matches the leading `:any` of `:any?` with nothing further
+    # to say it isn't the same shape. One rule with two languages' spellings
+    # of "untyped" must not let one spelling read the other's files.
     - regex: ":\\s*any\\b|<any>|as\\s+any\\b|Array<any>|:\\s*any\\[\\]"
+      scope: ["**/*.ts", "**/*.tsx"]
       message: "`any` opts the whole call chain out of type checking. `unknown` plus a narrowing check keeps the checker working; an interface keeps it useful."
     - regex: "interface\\{\\}"
+      scope: ["**/*.go"]
       message: "`interface{}` defers the decision to runtime. Define the interface you actually need, or use a type parameter."
     - regex: "\\.unwrap\\(\\)"
+      scope: ["**/*.rs"]
       message: "`.unwrap()` converts a case you have not handled into a crash with no message. Use `?` to propagate, or `.context(\"what was being attempted\")` so the failure says something."
     # Sorbet writes it `T.untyped`, RBS writes it `untyped`, and both mean
     # exactly what `Any` means: every call downstream stops being checked.
@@ -59,4 +68,5 @@ defaults:
     # `no-untyped-escape-hatch` — which is how this repository's own source
     # caught the first draft of this pattern.
     - regex: "(^|[^\\w-])untyped([^\\w-]|$)"
+      scope: ["**/*.rb", "**/*.rbs"]
       message: "`T.untyped` (and `untyped` in an .rbs) opts the whole call chain out of type checking. Use a `T::Struct` or an interface for a known shape, `T.type_parameter` for genuine passthrough, or `T.nilable`/`T.any` where the shape is a small union."

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -184,6 +184,14 @@ fn validate_patterns(options: &crate::policy::Options) -> Result<()> {
         if let Some(unless) = &pattern.unless {
             regex::Regex::new(unless).with_context(|| format!("invalid `unless` regex {unless:?}"))?;
         }
+        if !pattern.scope.is_empty() {
+            crate::scan::globs(&pattern.scope)
+                .with_context(|| format!("pattern {:?} has an invalid scope glob", pattern.regex))?;
+        }
+        if !pattern.exclude.is_empty() {
+            crate::scan::globs(&pattern.exclude)
+                .with_context(|| format!("pattern {:?} has an invalid exclude glob", pattern.regex))?;
+        }
     }
     if let Some(marker) = &options.marker {
         regex::Regex::new(marker).with_context(|| format!("invalid marker {marker:?}"))?;

--- a/src/checks/text_pattern.rs
+++ b/src/checks/text_pattern.rs
@@ -14,6 +14,7 @@ use crate::scan;
 use anyhow::{Context, Result};
 use regex::Regex;
 use crate::digest;
+use globset::GlobSet;
 
 /// A line that is nothing but a comment. Deliberately prefix-based rather
 /// than parsed: this engine runs on files no grammar covers, and a trailing
@@ -25,14 +26,26 @@ fn is_comment(line: &str) -> bool {
 
 pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx) -> Result<Vec<Finding>> {
     let selected = scan::select(ctx.files, &opts.scope, &opts.exclude)?;
-    let compiled: Vec<(Regex, Option<Regex>, &str)> = opts
+
+    struct Compiled<'a> {
+        forbidden: Regex,
+        unless: Option<Regex>,
+        message: &'a str,
+        // Per-pattern narrowing, one level under the rule's own scope/exclude.
+        scope: Option<GlobSet>,
+        exclude: Option<GlobSet>,
+    }
+
+    let compiled: Vec<Compiled> = opts
         .forbidden
         .iter()
         .map(|p| {
             let forbidden = Regex::new(&p.regex)
                 .with_context(|| format!("rule {} has an invalid regex", rule.id))?;
             let unless = p.unless.as_deref().map(Regex::new).transpose()?;
-            Ok((forbidden, unless, p.message.as_str()))
+            let scope = if p.scope.is_empty() { None } else { Some(scan::globs(&p.scope)?) };
+            let exclude = if p.exclude.is_empty() { None } else { Some(scan::globs(&p.exclude)?) };
+            Ok(Compiled { forbidden, unless, message: p.message.as_str(), scope, exclude })
         })
         .collect::<Result<_>>()?;
 
@@ -41,15 +54,25 @@ pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx) -> Result<Vec<Finding>> {
         let Ok(source) = std::fs::read_to_string(&file.abs) else {
             continue;
         };
+        // Narrow once per file, not once per line: a pattern's scope/exclude
+        // depends only on the path.
+        let active: Vec<&Compiled> = compiled
+            .iter()
+            .filter(|p| p.scope.as_ref().is_none_or(|g| g.is_match(&file.rel)))
+            .filter(|p| !p.exclude.as_ref().is_some_and(|g| g.is_match(&file.rel)))
+            .collect();
+        if active.is_empty() {
+            continue;
+        }
         for (number, line) in source.lines().enumerate() {
             if opts.ignore_comment_lines && is_comment(line) {
                 continue;
             }
-            for (forbidden, unless, message) in &compiled {
-                if !forbidden.is_match(line) {
+            for pattern in &active {
+                if !pattern.forbidden.is_match(line) {
                     continue;
                 }
-                if unless.as_ref().is_some_and(|u| u.is_match(line)) {
+                if pattern.unless.as_ref().is_some_and(|u| u.is_match(line)) {
                     continue;
                 }
                 // Key on the content, not the line number: moving a file's
@@ -61,7 +84,7 @@ pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx) -> Result<Vec<Finding>> {
                         rule.severity,
                         format!("{}:{}", file.rel, number + 1),
                         format!("{}:{digest}", file.rel),
-                        message.to_string(),
+                        pattern.message.to_string(),
                     )
                     .actual(line.trim().to_string()),
                 );
@@ -69,4 +92,100 @@ pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx) -> Result<Vec<Finding>> {
         }
     }
     Ok(findings)
+}
+
+/// The bug this file exists to fix: `L1.NO_UNTYPED_ESCAPE_HATCH`'s TypeScript
+/// `any` pattern used to have no per-language restriction, so it also read
+/// Ruby once commit #16 put `**/*.rb` in the rule's scope. `:\s*any\b`
+/// matches the leading `:any` of Ruby's `:any?` symbol — real PostPilot
+/// source, `delegate :any?, :empty?, :none?, to: :campaigns`, tripped it with
+/// nothing about `:any?` being untyped in the way `any` is.
+#[cfg(test)]
+mod ruby_does_not_read_typescripts_pattern {
+    use crate::catalog::Catalog;
+    use crate::checks::{self, Ctx};
+    use crate::policy::Policy;
+    use crate::ratchet::Ratchet;
+    use crate::scan;
+    use std::path::Path;
+
+    /// A scratch checkout on disk: this check reads `std::fs`, so there is no
+    /// way to exercise it without real files at real paths.
+    struct Scratch(std::path::PathBuf);
+
+    impl Scratch {
+        fn new(tag: &str) -> Scratch {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock is before the epoch")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!("sf-{tag}-{}-{nanos}", std::process::id()));
+            std::fs::create_dir_all(&path).expect("scratch directory");
+            Scratch(path)
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    const POLICY: &str = "version: 1\n\
+        project:\n  name: scoping\n  languages: [ruby]\n\
+        rules:\n  L1.NO_UNTYPED_ESCAPE_HATCH:\n    enabled: true\n";
+
+    fn findings_for(root: &Path, source: &str) -> Vec<crate::finding::Finding> {
+        std::fs::create_dir_all(root.join(".software-factory")).expect(".software-factory");
+        std::fs::write(root.join(".software-factory/policy.yaml"), POLICY).expect("policy.yaml");
+        std::fs::write(root.join("app.rb"), source).expect("app.rb");
+
+        let catalog = Catalog::builtin().expect("builtin catalog");
+        let policy = Policy::load(root).expect("policy loads");
+        let files = scan::walk(root, &policy).expect("walk");
+        let ratchet = Ratchet::default();
+        let rule =
+            catalog.get("L1.NO_UNTYPED_ESCAPE_HATCH").expect("the rule ships in the catalog");
+        let ctx = Ctx {
+            root,
+            policy: &policy,
+            catalog: &catalog,
+            files: &files,
+            ratchet: &ratchet,
+            changed: None,
+            base: None,
+            today: crate::clock::today(),
+            allow_commands: false,
+        };
+        checks::run_one(rule, &ctx).expect("check runs")
+    }
+
+    #[test]
+    fn delegate_any_predicate_is_not_the_untyped_escape_hatch() {
+        let scratch = Scratch::new("text-pattern-ruby-any");
+        let findings = findings_for(
+            scratch.0.as_path(),
+            "class CampaignCollectionPresenter\n  \
+             delegate :any?, :empty?, :none?, to: :campaigns\nend\n",
+        );
+        assert!(
+            findings.is_empty(),
+            "the TypeScript `any` pattern fired on a Ruby `:any?` symbol: {:?}",
+            findings.iter().map(|f| f.actual.clone()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn t_dot_untyped_still_fires_on_ruby() {
+        let scratch = Scratch::new("text-pattern-ruby-untyped");
+        let findings = findings_for(
+            scratch.0.as_path(),
+            "sig { params(event: T.untyped).returns(T.untyped) }\n\
+             def handle(event)\n  event\nend\n",
+        );
+        assert!(
+            !findings.is_empty(),
+            "the rule's own escape hatch, T.untyped, must still fire on Ruby"
+        );
+    }
 }

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -176,10 +176,26 @@ pub const FIXTURES: &[Fixture] = &[
         rule: "L1.NO_UNTYPED_ESCAPE_HATCH",
         policy_extra: "",
         extra_rules: "",
+        // One file per language the rule's patterns are now scoped to, so a
+        // restriction that accidentally excludes a pattern's own language —
+        // the same mistake this rule exists to catch one level up — cannot
+        // hide behind the other files still tripping the rule overall.
         files: &[
             (
                 "src/payload.py",
                 "from typing import Any\n\n\ndef handle(event: dict) -> Any:\n    return event\n",
+            ),
+            (
+                "src/handler.ts",
+                "function handle(event: any): any {\n  return event;\n}\n",
+            ),
+            (
+                "src/handler.go",
+                "package payload\n\nfunc Handle(event interface{}) interface{} {\n\treturn event\n}\n",
+            ),
+            (
+                "src/handler.rs",
+                "fn parse(raw: &str) -> i64 {\n    raw.parse::<i64>().unwrap()\n}\n",
             ),
             (
                 "src/payload.rb",

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -97,6 +97,18 @@ pub struct TextPattern {
     /// Shown verbatim on failure. This is the agent-facing documentation:
     /// it must name the alternative, not just the ban.
     pub message: String,
+    /// Restrict *this pattern* to a subset of the rule's own `scope` — the
+    /// same glob vocabulary, one level down. A rule with several spellings
+    /// of one concept, one per language, must not point language B's
+    /// spelling at language A's files: `:\s*any\b` is TypeScript's `any`,
+    /// but it also matches Ruby's `:any?` symbol wherever both live under
+    /// the same rule's scope. Empty means "wherever the rule's scope
+    /// already reaches", so a rule with one flat pattern list — the common
+    /// case — is unaffected.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub scope: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclude: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
## The defect, measured

`L1.NO_UNTYPED_ESCAPE_HATCH` is `kind: text_pattern`: a flat list of regexes run against every file its `scope` reaches, with no per-language restriction. #16 added `**/*.rb` and `**/*.rbs` to that scope so Ruby's `T.untyped`/`untyped` could be covered — but every other pattern in the same list, including TypeScript's `:\s*any\b|<any>|as\s+any\b|Array<any>|:\s*any\[\]`, is now also run against every Ruby file.

Rolling this out on **PostPilot** (a Rails monorepo, ~4,700 `.rb` files) right after upgrading its `sf` install to a Ruby-aware one produced this finding on completely correct Ruby:

```
app/presenters/campaigns_strategies/campaign_collection_presenter.rb:7
delegate :any?, :empty?, :none?, to: :campaigns
```

`:\s*any\b` matches the leading `:any` of the `:any?` symbol. `delegate :any?, ...` and bare `:any?` are everywhere in idiomatic Ruby — this is not a one-off finding, it is every file that delegates an `Enumerable` predicate. The same class of bug applies to `.unwrap()` (a Rust idiom that would also fire on any other scoped language exposing an `.unwrap()` method) and to `from typing import Any` (Python-only, but reachable by every file the flat scope covers).

**PostPilot has `L1.NO_UNTYPED_ESCAPE_HATCH` switched off today, specifically because of this.**

Note the irony: the rule's own `untyped` pattern already carries a comment explaining it was tightened from `\buntyped\b` because `\b` alone fires on this repository's own filename `no-untyped-escape-hatch`. This is the same mistake one level up — narrowing the token isn't enough if the file it's allowed to read is still unbounded.

## The fix

`TextPattern` (`src/policy.rs`) gains optional `scope`/`exclude` glob lists — the same vocabulary and empty-means-everywhere semantics the rule level already has via `scan::select`, one level down, applied per forbidden entry in `src/checks/text_pattern.rs`. Chosen over a `languages: [ruby]` field (which would need the check to map every file to a `Lang` and cross-reference a declared list) because it's a smaller diff, reuses machinery (`scan::globs`) the check already imports, and is exactly as easy or hard to get right as the `scope`/`exclude` a rule author already writes at the top of the same file. `src/catalog.rs` validates the new globs at rule-load time, same as it already validates the regexes. An entry with no `scope`/`exclude` still applies everywhere the rule's own scope reaches, so `L1.NO_BLANKET_SUPPRESSION` (the only other `kind: text_pattern` rule) is unaffected by the schema change.

`catalog/L1/no-untyped-escape-hatch.yaml` restricts every pattern to its real language: `typing.Any` → Python, the `any` family → TypeScript/TSX, `interface{}` → Go, `.unwrap()` → Rust, `untyped` → Ruby and RBS.

**Audit of every other `kind: text_pattern` rule:** `L1.NO_BLANKET_SUPPRESSION` is the only other one in the catalog. Its patterns (`# noqa`, `@ts-ignore`, `eslint-disable`, `//nolint`, `#[allow(`, `rubocop:disable`) are all full suppression-directive strings, not short common identifiers — none of them plausibly collides with legitimate code in another of the rule's scoped languages the way `:any?` collided with TypeScript's `any`. No change made there.

`src/fixtures.rs` adds a TypeScript, Go and Rust file to the `L1.NO_UNTYPED_ESCAPE_HATCH` fixture (the Ruby `T.untyped` fixture already existed) so `sf verify` proves every one of the rule's six declared languages still trips its own restricted pattern — after `sf fixtures` regenerated `.software-factory/mutations/L1.NO_UNTYPED_ESCAPE_HATCH/`, the fixture now reports 6 findings, one per language.

`src/checks/text_pattern.rs` adds the regression test this bug needed: Ruby source with `delegate :any?, :empty?, :none?, to: :campaigns` produces **no** finding, while `T.untyped` still does.

## Mutation proof

With the `scope: ["**/*.ts", "**/*.tsx"]` restriction reverted from the `any` pattern in `catalog/L1/no-untyped-escape-hatch.yaml`, `cargo test --release text_pattern`:

```
running 2 tests
test checks::text_pattern::ruby_does_not_read_typescripts_pattern::t_dot_untyped_still_fires_on_ruby ... ok
test checks::text_pattern::ruby_does_not_read_typescripts_pattern::delegate_any_predicate_is_not_the_untyped_escape_hatch ... FAILED

---- checks::text_pattern::ruby_does_not_read_typescripts_pattern::delegate_any_predicate_is_not_the_untyped_escape_hatch stdout ----
thread '...' panicked at src/checks/text_pattern.rs:171:9:
the TypeScript `any` pattern fired on a Ruby `:any?` symbol: [Some("delegate :any?, :empty?, :none?, to: :campaigns")]

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 17 filtered out
```

Restoring the restriction and rebuilding returns both tests to green.

## Verification (in a dedicated worktree off `upstream/main`)

```
cargo build --release --locked                                        ✓
./target/release/sf verify --allow-commands                           ✓ 30/30 enabled rules proven to fire
./target/release/sf check --allow-commands --changed upstream/main    ✓ 30 rules, no findings (1 frozen by the ratchet)
cargo test                                                             ✓ 19 passed
cargo clippy --all-targets -- -D warnings -D dead_code                 ✓ clean
```
