### PR TITLE
fix(release): sf check --allow-commands rewrote the locks it was checking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,11 @@ jobs:
           persist-credentials: false
       - run: rustup target add ${{ matrix.target }}
       - run: cargo build --release --locked --target ${{ matrix.target }}
-      # The digest travels with the binary. A consumer who downloads this and
-      # a consumer who builds from the tag must be able to confirm they are
-      # enforcing the same catalog, and the version number alone does not say
-      # that.
+      # A checksum beside each binary, so somebody who downloads one can say
+      # they got what this run built. The catalog digest a consumer needs in
+      # order to know which rules they are enforcing is not shipped as a file:
+      # it is in the binary, printed by `sf --version`, and repeated in the
+      # release notes. A separate file would be a second copy to drift.
       - name: Package
         env:
           TARGET: ${{ matrix.target }}
@@ -77,8 +78,16 @@ jobs:
           set -eu
           mkdir -p dist
           cp "target/$TARGET/release/sf" "dist/sf-$TARGET"
-          ( cd dist && shasum -a 256 "sf-$TARGET" > "sf-$TARGET.sha256" )
-          "target/$TARGET/release/sf" --version > "dist/sf-$TARGET.version" || true
+          # `sha256sum` on Linux, `shasum` on macOS. Neither is on both, and
+          # picking one would have failed exactly one of the three build jobs
+          # after everything else in them had already passed.
+          cd dist
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "sf-$TARGET" > "sf-$TARGET.sha256"
+          else
+            shasum -a 256 "sf-$TARGET" > "sf-$TARGET.sha256"
+          fi
+          cat "sf-$TARGET.sha256"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sf-${{ matrix.target }}

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -3,9 +3,9 @@
   "files": {
     ".allowed-root-files": "20889fd9828de3c601e63bae4c430692846319df116688c1322bd230bdfc1995",
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
-    ".github/workflows/release.yml": "cf84144a0130eb530fd5b79ba42da89c0df5b37e67409406d15bd51fa306af8f",
+    ".github/workflows/release.yml": "cf41f42fafe38dec1582db3898a8097260128585b4f51e47350b71d19bc3d7f3",
     ".github/workflows/software-factory.yml": "0350f6ff218f228765453461949d2c9b7ce5158c0705a7968c332a7b629f7eab",
-    ".software-factory/policy.yaml": "42ae51b4cb452e0aa7fdf5638b49cd5fca86231084f65d7c8358760c2f92394b",
+    ".software-factory/policy.yaml": "563edd7a4f92e19195e262c40d71420296b9ec74f6875839fe7550bc712afb63",
     ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"
   }
 }

--- a/.software-factory/policy.yaml
+++ b/.software-factory/policy.yaml
@@ -115,6 +115,15 @@ rules:
       # writes into somebody else's repository pinning a version this build is
       # not. The release workflow runs the same four through this rule, so the
       # gate is one definition rather than a copy in CI.
+      #
+      # Every one of the four is read-only, and that is load-bearing rather
+      # than tidy. The first draft ran `sf lock` here and compared the result
+      # with `git diff`, which rewrote every lock file in the middle of
+      # `sf check --allow-commands` and so erased the evidence
+      # `L2.FACTORY_CONFIG_IS_LOCKED` and `L2.DEPENDENCIES_CHANGE_DELIBERATELY`
+      # exist to read. Both reported green on a modified locked file. A
+      # `kind: command` rule runs inside a check that is otherwise read-only;
+      # it does not get to write.
       run: |
         set -eu
         version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
@@ -122,7 +131,10 @@ rules:
         test "$version" = "$binary" || { echo "Cargo.toml says $version, the binary reports $binary"; exit 1; }
         grep -q "name = \"sf\"" -A 1 Cargo.lock && test "$(grep -A 1 'name = "sf"' Cargo.lock | sed -n 's/^version = "\(.*\)"/\1/p')" = "$version" || { echo "Cargo.lock does not name version $version for sf"; exit 1; }
         grep -q -- "--tag v$version" README.md || { echo "README.md does not tell a consumer to install --tag v$version"; exit 1; }
-        ./target/release/sf lock >/dev/null && git diff --exit-code -- .software-factory/catalog.lock.json
+        locked=$(sed -n 's/.*"catalog_digest": "\([0-9a-f]*\)".*/\1/p' .software-factory/catalog.lock.json)
+        running=$(./target/release/sf --version | sed -n 's/.*catalog \([0-9a-f]*\).*/\1/p')
+        test -n "$locked" && test -n "$running" || { echo "could not read the catalog digest from the lock or from sf --version"; exit 1; }
+        case "$locked" in "$running"*) ;; *) echo "the committed catalog fingerprint names $locked and this binary carries $running — run sf lock"; exit 1 ;; esac
 
   # L2 — Every frozen exception carries a future review date
   L2.NO_PERMANENT_EXCEPTION:


### PR DESCRIPTION
Two defects in the release pipeline #22 shipped. Both found before the first tag existed, which is the only reason this is a pull request and not a bad release.

## The critical one: `sf check` erased its own evidence

`L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE@release` ended its command with:

```sh
./target/release/sf lock >/dev/null && git diff --exit-code -- .software-factory/catalog.lock.json
```

`sf lock` rewrites **every** lock file. Running it inside `sf check --allow-commands` therefore erased the evidence `L2.FACTORY_CONFIG_IS_LOCKED` and `L2.DEPENDENCIES_CHANGE_DELIBERATELY` exist to read, in the middle of the run that was supposed to read it.

Both went silently green on a modified locked file. That is the exact failure the lock rules are for, and `.github/workflows/software-factory.yml` runs that command on every pull request.

Measured on `b2d5bbb`:

```
$ echo "# probe" >> .github/workflows/release.yml
$ ./target/release/sf check --allow-commands
✓ 32 rules, no findings (1 frozen by the ratchet)

lock before the check: cf41f42fafe38dec
lock after  the check: 2f56be54c35bb54f
```

The lock ended the run holding the hash of the file I had just edited. Two critical rules off, no output.

Found while investigating why `sf check` stayed green after I edited `release.yml` on this branch. The rule I had added in #22 to protect the release was disabling the rule that protects the guardrail.

**The fix.** The fourth assertion is read-only. It compares the `catalog_digest` committed in the fingerprint against the one `sf --version` reports, and writes nothing:

```sh
locked=$(sed -n 's/.*"catalog_digest": "\([0-9a-f]*\)".*/\1/p' .software-factory/catalog.lock.json)
running=$(./target/release/sf --version | sed -n 's/.*catalog \([0-9a-f]*\).*/\1/p')
case "$locked" in "$running"*) ;; *) ...exit 1 ;; esac
```

The staleness it was written to catch is still caught. The policy comment now says why every one of the four assertions has to stay read-only, so the next person does not reintroduce it.

## The second: the Linux build job would have failed

The Package step used `shasum -a 256`. That is macOS; Linux has `sha256sum`. Neither is on both, so **exactly one of the three build jobs would have failed** after everything else in it passed, and there would have been no release.

Now it picks whichever exists and prints the checksum, so a failed download has something to compare against. Verified locally against the command the README tells a consumer to run:

```
$ sha256sum sf-x > sf-x.sha256   # or shasum -a 256
$ shasum -a 256 -c sf-x.sha256
sf-x: OK
```

Also dropped the `.version` asset. The cross-compiled `x86_64-apple-darwin` binary cannot run on the arm64 runner that builds it, so the `|| true` was shipping an empty file, and the catalog digest a consumer needs is already in the binary and repeated in the release notes. The comment above the step justified that file, so it was rewritten rather than left lying.

## Proofs

All three run on this branch, each reverted after.

**1. `L2.FACTORY_CONFIG_IS_LOCKED` sees an edit again, and the check no longer writes:**

```
.github/workflows/release.yml — a locked file was modified without updating the lock
>>> and the check did NOT rewrite the lock
```

**2. `L2.DEPENDENCIES_CHANGE_DELIBERATELY` sees one again:**

```
Cargo.toml — a locked file was modified without updating the lock
```

**3. A stale fingerprint is still caught, without writing:**

```
✗ critical L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE@release
  the committed catalog fingerprint names 000000... and this binary carries ddde87d963b7 — run sf lock
```

## Verification contract

```
$ ./target/release/sf verify --allow-commands
31/31 enabled rules proven to fire

$ ./target/release/sf check --allow-commands
✓ 32 rules, no findings (1 frozen by the ratchet)

$ cargo test
test result: ok. 29 passed

$ cargo clippy --all-targets -- -D warnings -D dead_code
clean

$ actionlint .github/workflows/release.yml
only the known info-level SC2016, documented in the file
```

`sf fixtures`, `sf docs`, `sf ratchet`, `sf lock` in that order. `sf ratchet` froze nothing new.

## The general lesson, not fixed here

A `kind: command` rule runs arbitrary commands inside a check that is otherwise read-only, and **nothing in `sf` stops one from writing to the repository.** This bug is one instance; the class is open. `AGENTS.md` already says "never hand-edit a digest or a lock", and a `run:` command is a way to edit one without a hand. Worth its own plan rather than a line here, since the honest options (sandbox the command, run it against a copy, or declare which paths it may touch) are a design decision.

## No release yet, and why

Merging #22 did not produce a release: the workflow fires on `push` of a `v*` tag, and no tag exists. Nothing is wrong with the trigger. Once this merges, `v0.2.0` is ready to tag — the gate passes locally on `main` at all five steps, and the binary reports `v0.2.0`, matching what the tag check will demand.
