### PR TITLE
fix(release): publish fills an existing release instead of failing on it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,10 +141,26 @@ jobs:
           TAG: ${{ github.ref_name }}
         # `gh` is on the runner already. A third-party release action would be
         # one more SHA to pin and one more thing holding a write token.
+        #
+        # Create-or-fill, not create. Drafting a release in the GitHub UI
+        # creates the tag *and* the release, so the tag push that starts this
+        # workflow can arrive at a release that already exists, and
+        # `gh release create` fails on it. That is how v0.2.0 shipped with the
+        # gate green, all three binaries built, and zero assets attached.
+        #
+        # Notes are left alone when the release already exists. Whoever created
+        # it may have written them, and overwriting somebody's release notes to
+        # insert generated ones is worse than not having the generated ones.
         run: |
           set -eu
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes-file notes.md \
-            --verify-tag \
-            artifacts/*
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "release $TAG already exists, uploading assets to it"
+            gh release upload "$TAG" --clobber artifacts/*
+            echo "notes left as they are; this run did not write them"
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes-file notes.md \
+              --verify-tag \
+              artifacts/*
+          fi

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -3,7 +3,7 @@
   "files": {
     ".allowed-root-files": "20889fd9828de3c601e63bae4c430692846319df116688c1322bd230bdfc1995",
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
-    ".github/workflows/release.yml": "cf41f42fafe38dec1582db3898a8097260128585b4f51e47350b71d19bc3d7f3",
+    ".github/workflows/release.yml": "876953c1e0277e4c35663ecd742bbeebc9f7483e5a6ae5a370394987f3a55112",
     ".github/workflows/software-factory.yml": "0350f6ff218f228765453461949d2c9b7ce5158c0705a7968c332a7b629f7eab",
     ".software-factory/policy.yaml": "563edd7a4f92e19195e262c40d71420296b9ec74f6875839fe7550bc712afb63",
     ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,12 @@ why nothing here tracks the tip of `main`.
   against the tagged commit, refuses a tag that disagrees with the built
   version, builds Linux and both macOS targets, and generates the notes from
   `sf --version` and `sf catalog` rather than from a hand-written changelog.
+- **Create the tag with git, not with the GitHub UI.** "Draft a new release"
+  creates the tag *and* an empty release, and the workflow is what should be
+  creating the release. It now fills an existing one instead of failing on it,
+  but that path leaves the notes as the UI generated them rather than as
+  `sf catalog` describes them. `git tag v0.3.0 && git push origin v0.3.0` is
+  the whole ceremony.
 
 ## Working model
 


### PR DESCRIPTION
## What happened

`v0.2.0` shipped with **zero assets**. The gate passed, all three binaries built, and only `publish` failed:

```
$ gh run view 33020422152 --log-failed
publish  Publish  a release with the same tag name already exists: v0.2.0
publish  Publish  ##[error]Process completed with exit code 1.
```

Drafting a release in the GitHub UI creates the tag **and** the release. The tag push starts this workflow, which then arrives at a release that already exists, and `gh release create` refuses it.

Worth stating plainly since I flagged the opposite risk in #22: **this was not the token.** I had worried `default_workflow_permissions: read` would cap the job-level `contents: write`. It does not — the API models it as a default, not a cap, and the `publish` job authenticated and reached the API fine. The gate, the version check and all three build jobs were green.

## The fix

Publish is create-or-fill:

```sh
if gh release view "$TAG" >/dev/null 2>&1; then
  gh release upload "$TAG" --clobber artifacts/*
else
  gh release create "$TAG" --title "$TAG" --notes-file notes.md --verify-tag artifacts/*
fi
```

`--clobber` also makes a re-run of a partially uploaded release safe.

**Notes are left alone on the existing-release path, deliberately.** Whoever created the release may have written them, and overwriting somebody's release notes to insert generated ones is worse than not having the generated ones. The step prints that it did not write them, so a run that took that path says so instead of leaving you guessing.

`AGENTS.md` gains one line: create the tag with `git tag` and `git push`, not the UI, because the UI path is the one that loses the generated notes.

## v0.2.0 is now complete

Repaired by hand from the failed run's artifacts, which were intact and unexpired. Verified rather than assumed:

```
$ shasum -a 256 -c *.sha256          # the command the README tells a consumer to run
sf-aarch64-apple-darwin: OK
sf-x86_64-apple-darwin: OK
sf-x86_64-unknown-linux-gnu: OK

$ file -b sf-*
Mach-O 64-bit executable arm64
Mach-O 64-bit executable x86_64
ELF 64-bit LSB pie executable, x86-64

$ ./sf-aarch64-apple-darwin --version
sf 0.2.0 (catalog ddde87d963b7, 35 rules)     # matches a local build of the tag
```

Six assets attached. The release notes gained the version and catalog line the workflow would have written, prepended above the auto-generated PR list rather than replacing it.

One thing the failed release did prove: the `shasum`/`sha256sum` fix from #23 works. The Linux build job passing is that proof, and it is the job that would have failed without it.

## Verification

```
$ ./target/release/sf verify --allow-commands
31/31 enabled rules proven to fire

$ ./target/release/sf check --allow-commands
✓ 32 rules, no findings (1 frozen by the ratchet)

$ cargo test
test result: ok. 29 passed

$ actionlint .github/workflows/release.yml
only the known info-level SC2016, documented in the file
```

`sf lock` re-run, since `release.yml` is inside `L2.FACTORY_CONFIG_IS_LOCKED`'s scope in this repository's policy.

No mutation proof for the branch itself: the failure mode needs a real GitHub release to exist, which is not something a fixture can hold. The evidence is the failed run above, and the next tag is the test.
