### PR TITLE
fix(checks): a tool named only in a comment no longer satisfies the toolchain rules

### DIFF
--- a/src/checks/toolchain.rs
+++ b/src/checks/toolchain.rs
@@ -25,6 +25,7 @@ pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx) -> Result<Vec<Finding>> {
     let runners: Vec<String> = scan::select(ctx.files, &opts.scope, &opts.exclude)?
         .iter()
         .filter_map(|file| std::fs::read_to_string(&file.abs).ok())
+        .map(|content| without_comment_lines(&content))
         .collect();
     let haystack = runners.join("\n");
 
@@ -35,7 +36,10 @@ pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx) -> Result<Vec<Finding>> {
             // is a statement about the ecosystem, not a violation.
             continue;
         };
-        if candidates.iter().any(|tool| haystack.contains(tool.as_str())) {
+        if candidates
+            .iter()
+            .any(|tool| haystack.contains(tool.as_str()))
+        {
             continue;
         }
         findings.push(
@@ -51,4 +55,43 @@ pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx) -> Result<Vec<Finding>> {
         );
     }
     Ok(findings)
+}
+
+/// A mention of a tool inside a comment is prose, not a wired-in guarantee.
+/// `sf init` itself writes explanatory `#` comments naming the tools next to
+/// the steps that run them, so counting comment text let a freshly generated
+/// workflow satisfy these rules all by itself. Every file in scope here
+/// (YAML workflows, Makefile, justfile, Taskfile, .gitlab-ci.yml,
+/// .pre-commit-config.yaml, package.json) uses `#` for comments or none at
+/// all, so dropping `#`-leading lines cannot hide a real invocation — those
+/// are `uses:`/`run:`/recipe lines, which never start with `#`.
+fn without_comment_lines(content: &str) -> String {
+    content
+        .lines()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::without_comment_lines;
+
+    #[test]
+    fn a_tool_named_only_in_a_comment_is_not_evidence() {
+        let workflow = "\
+  # Committed secrets: we run gitleaks on every push.\n\
+  # (comment-only mention: nothing here actually invokes gitleaks)\n";
+        let stripped = without_comment_lines(workflow);
+        assert!(!stripped.contains("gitleaks"));
+    }
+
+    #[test]
+    fn a_real_invocation_survives_the_comment_strip() {
+        let workflow = "\
+  # Committed secrets: scanned by gitleaks.\n\
+  - uses: gitleaks/gitleaks-action@v2\n";
+        let stripped = without_comment_lines(workflow);
+        assert!(stripped.contains("gitleaks"));
+    }
 }


### PR DESCRIPTION
## What I was doing

After opening #25 I went looking for the root cause in the source rather than arguing from the repro.

## Root cause

`check_for` in `src/checks/toolchain.rs` concatenates the raw text of every file in the rule's scope and decides with a substring test:

```rust
if candidates.iter().any(|tool| haystack.contains(tool.as_str())) {
```

A substring match cannot tell a wired-in tool from a mention of the tool's name. Meanwhile `fn workflow` in `src/init.rs` writes `.github/workflows/software-factory.yml` — inside the very scope these rules scan — with explanatory `#` comments naming the tools right next to the steps that run them. So on every fresh install, prose that `sf init` itself wrote satisfies `L6.SECRETS_ARE_SCANNED` (and every sibling rule of `check.kind: toolchain`) before any tool has ever run.

The measured shape of the failure (from #25):

- fresh `sf init` repo → rule silent, because its own generated comment says `gitleaks`
- delete the generated workflow → `✗ critical L6.SECRETS_ARE_SCANNED`
- restore the workflow with the `uses:` line commented out → silent again, on the same substring

## The change

- `toolchain.rs` strips `#`-leading lines from each file before building the haystack. Every file in scope (YAML workflows, Makefile, justfile, Taskfile, `.gitlab-ci.yml`, `.pre-commit-config.yaml`, `package.json`) uses `#` for comments or none at all, and real invocations (`uses:`/`run:`/recipe lines) never start with `#`, so the strip cannot hide evidence.
- Known remaining limit, stated rather than hidden: the match is still textual, so it proves *presence of an invocation line*, not that the tool ever ran. Fixing that needs structural parsing of the workflow — a separate, larger change if you want it.

## Proof

Built from this branch, same 4-command repro:

```sh
$ sf init --name x --language python --layer L1,L4,L5,L6 && git add -A && git commit -qm init
$ sf check | grep -c SECRETS_ARE_SCANNED
0        # still silent: the real `uses: gitleaks/gitleaks-action` line survives the comment strip
$ git rm -q .github/workflows/software-factory.yml && git commit -qm rm && sf check
✗ critical L6.SECRETS_ARE_SCANNED
$ git checkout HEAD~1 -- .github/workflows/software-factory.yml   # uses: line commented out
$ sf check
✗ critical L6.SECRETS_ARE_SCANNED   # was silent before this branch — the bug
```

Unit tests: `a_tool_named_only_in_a_comment_is_not_evidence`, `a_real_invocation_survives_the_comment_strip`.

Fixes #25
