### PR TITLE
feat(L1): a comment block stays under the line ceiling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,12 +110,11 @@ jobs:
           merge-multiple: true
       - run: cargo build --release --locked
       # Release notes are generated, not written. `sf --version` carries the
-      # catalog digest, and the catalog lock carries the reach of every rule
-      # this repository enables — which is exactly what a consumer needs in
-      # order to decide whether upgrading is safe. A hand-written changelog is
-      # a second list somebody forgets to update, the same argument
-      # `L4.RULE_PROSE_NAMES_A_REAL_COMMAND` already makes about prose naming
-      # a command.
+      # catalog digest and the lock carries every enabled rule's reach, which
+      # is what a consumer needs to judge whether upgrading is safe. A
+      # hand-written changelog is a second list somebody forgets — the
+      # argument `L4.RULE_PROSE_NAMES_A_REAL_COMMAND` already makes about
+      # prose naming a command.
       - name: Compose the notes
         env:
           TAG: ${{ github.ref_name }}

--- a/.software-factory/catalog.lock.json
+++ b/.software-factory/catalog.lock.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "sf_version": "0.2.0",
-  "catalog_digest": "9f03093ac12d46845aa8dc5a1ca1465d7d1edffe278a99683e3851df5a44b258",
+  "catalog_digest": "cb1870a2fac286e0a025a40f621a40998637f2f41d0323281b45f7afbedda810",
   "rules": {
     "L0.EXCEPTIONS_HAVE_ONE_HOME": {
       "severity": "high",
@@ -23,6 +23,18 @@
       "languages": 5,
       "tools": 0,
       "must_live_in": 4,
+      "must_not_live_in": 0
+    },
+    "L1.COMMENT_STAYS_SUCCINCT": {
+      "severity": "medium",
+      "scope": 13,
+      "exclude": 4,
+      "max": 6,
+      "forbidden": 0,
+      "narrowed_patterns": 0,
+      "languages": 0,
+      "tools": 0,
+      "must_live_in": 0,
       "must_not_live_in": 0
     },
     "L1.COMPLEXITY_CEILING": {

--- a/.software-factory/evidence/adoption-run.json
+++ b/.software-factory/evidence/adoption-run.json
@@ -7,13 +7,13 @@
     "commit": "cd135c71e1debc55c20e08059749fe37ee943e21",
     "tracked_files": 1232
   },
-  "sf": "sf 0.2.0 (catalog 9f03093ac12d, 35 rules)",
+  "sf": "sf 0.2.0 (catalog cb1870a2fac2, 36 rules)",
   "observed": {
-    "rules_enabled_by_init": 13,
-    "violations_frozen_at_init": 1737,
-    "verify": "13/13 enabled rules proven to fire",
-    "check_on_baseline": "✓ 13 rules, no findings (2833 frozen by the ratchet)",
-    "check_after_one_new_violation": "2 findings across 2 rules (2833 frozen by the ratchet)"
+    "rules_enabled_by_init": 14,
+    "violations_frozen_at_init": 1745,
+    "verify": "14/14 enabled rules proven to fire",
+    "check_on_baseline": "✓ 14 rules, no findings (2841 frozen by the ratchet)",
+    "check_after_one_new_violation": "2 findings across 2 rules (2841 frozen by the ratchet)"
   },
   "assertions": [
     { "type": "cli.init_scaffolds_a_policy", "status": "passed" },

--- a/.software-factory/evidence/adoption.json
+++ b/.software-factory/evidence/adoption.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "adoption",
-  "implementation_sha256": "4aa8aa231c689b34d36a4f0c76ffd0354bfccebedffc186fcab6ae75a220183b",
+  "implementation_sha256": "d513e09938fb62b67dce7b8d44a4648d1280315de56ea742cd6deaaf68d059b0",
   "runs": [
     {
       "scenario": "adoption",
       "status": "passed",
       "actor": "Claude (agent), running .software-factory/evidence/adoption-scenario.sh against a scratch checkout of palmares, for Nicolas Melo",
       "report": ".software-factory/evidence/adoption-run.json",
-      "report_sha256": "1246c6af1cfe3ca34b24bd0a645adbbcfbbd29649509befd61a03eba519f1f66",
+      "report_sha256": "a3e91a21f6c92525fcc49004aa6b932c67e7fb4f547a4e08cfc5d7eca09e9f8b",
       "required_assertions": []
     }
   ]

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -5,7 +5,7 @@
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
     ".github/workflows/release.yml": "876953c1e0277e4c35663ecd742bbeebc9f7483e5a6ae5a370394987f3a55112",
     ".github/workflows/software-factory.yml": "0350f6ff218f228765453461949d2c9b7ce5158c0705a7968c332a7b629f7eab",
-    ".software-factory/policy.yaml": "8a991158980dbaa6e9bd8d57240ce5ff6567875438e2be84e09d84a760b1c971",
-    ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"
+    ".software-factory/policy.yaml": "00ece98a47fc7b7dae7f9d727eb19c5a4c7ae6244e6b3a4dc25425930d16c75f",
+    ".software-factory/ratchet.yaml": "a55eff526191af0cd9954f25766a51bb2217d0d8b6aa6f9a746e09be2fff2457"
   }
 }

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -3,9 +3,9 @@
   "files": {
     ".allowed-root-files": "20889fd9828de3c601e63bae4c430692846319df116688c1322bd230bdfc1995",
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
-    ".github/workflows/release.yml": "876953c1e0277e4c35663ecd742bbeebc9f7483e5a6ae5a370394987f3a55112",
+    ".github/workflows/release.yml": "b8beb43a7b8606aa17a79e069426798f4dd16e169493805a2205abc3213bc002",
     ".github/workflows/software-factory.yml": "0350f6ff218f228765453461949d2c9b7ce5158c0705a7968c332a7b629f7eab",
-    ".software-factory/policy.yaml": "00ece98a47fc7b7dae7f9d727eb19c5a4c7ae6244e6b3a4dc25425930d16c75f",
-    ".software-factory/ratchet.yaml": "a55eff526191af0cd9954f25766a51bb2217d0d8b6aa6f9a746e09be2fff2457"
+    ".software-factory/policy.yaml": "b217cef62efa3e01aa0cd12edfbc4258a27ddc85ef7421eaa97ed83ad290d1c2",
+    ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"
   }
 }

--- a/.software-factory/mutations/L1.COMMENT_STAYS_SUCCINCT/.software-factory/policy.yaml
+++ b/.software-factory/mutations/L1.COMMENT_STAYS_SUCCINCT/.software-factory/policy.yaml
@@ -1,0 +1,13 @@
+# Generated mutation fixture for L1.COMMENT_STAYS_SUCCINCT. It is supposed to fail.
+version: 1
+project:
+  name: mutation-L1.COMMENT_STAYS_SUCCINCT
+  languages: [python, typescript, go, rust, ruby]
+docs:
+  scan: ["docs/**/*.md"]
+gates: {}
+rules:
+  L1.COMMENT_STAYS_SUCCINCT:
+    enabled: true
+    options:
+        max: 3

--- a/.software-factory/mutations/L1.COMMENT_STAYS_SUCCINCT/src/notes.py
+++ b/.software-factory/mutations/L1.COMMENT_STAYS_SUCCINCT/src/notes.py
@@ -1,0 +1,8 @@
+# One reason per line, four lines deep, which is one more than
+# this fixture's ceiling allows and therefore the finding this
+# rule exists to produce. The run below stays under it, so a rule
+# that fired unconditionally would be caught here too.
+VALUE = 1
+
+# Kept small on purpose.
+OTHER = 2

--- a/.software-factory/mutations/L1.COMMENT_STAYS_SUCCINCT/src/settings.yaml
+++ b/.software-factory/mutations/L1.COMMENT_STAYS_SUCCINCT/src/settings.yaml
@@ -1,0 +1,8 @@
+# The retry budget is per attempt, not per job, because a job
+# that lost its lease has already consumed the attempt it was
+# leased for, and counting it twice turns a single slow worker
+# into an outage that looks like a retry storm.
+retries: 3
+
+# Per attempt.
+timeout: 30

--- a/.software-factory/policy.yaml
+++ b/.software-factory/policy.yaml
@@ -35,6 +35,9 @@ gates:
       - "cli.new_violation_fails_the_check"
 
 rules:
+  # L1 — A comment block stays under the line ceiling
+  L1.COMMENT_STAYS_SUCCINCT:
+    enabled: true
   # L0 — Error types live in one canonical module per domain
   L0.EXCEPTIONS_HAVE_ONE_HOME:
     enabled: true

--- a/.software-factory/policy.yaml
+++ b/.software-factory/policy.yaml
@@ -127,24 +127,21 @@ rules:
     enabled: true
     options:
       # Everything downstream of the version number in Cargo.toml, compared
-      # rather than trusted. A tag is the only thing a consumer can pin to,
-      # and each of these four is a way for a tag to promise something the
-      # binary does not deliver: a lockfile still naming the old version, an
-      # install line in the README pointing at a tag that predates the rules
-      # it documents, a catalog fingerprint nobody refreshed so the next
-      # upgrade compares against a stale baseline, and the workflow `sf init`
-      # writes into somebody else's repository pinning a version this build is
-      # not. The release workflow runs the same four through this rule, so the
-      # gate is one definition rather than a copy in CI.
+      # rather than trusted. A tag is all a consumer can pin to, and each of
+      # these four is a way for one to promise what the binary does not
+      # deliver: a stale lockfile, a README install line predating the rules
+      # it documents, an unrefreshed catalog fingerprint, and the workflow
+      # `sf init` writes elsewhere pinning a version this build is not.
       #
-      # Every one of the four is read-only, and that is load-bearing rather
-      # than tidy. The first draft ran `sf lock` here and compared the result
-      # with `git diff`, which rewrote every lock file in the middle of
-      # `sf check --allow-commands` and so erased the evidence
-      # `L2.FACTORY_CONFIG_IS_LOCKED` and `L2.DEPENDENCIES_CHANGE_DELIBERATELY`
-      # exist to read. Both reported green on a modified locked file. A
-      # `kind: command` rule runs inside a check that is otherwise read-only;
-      # it does not get to write.
+      # The release workflow runs the same four through this rule, so the gate
+      # is one definition rather than a copy in CI.
+      #
+      # All four are read-only, and that is load-bearing. The first draft ran
+      # `sf lock` here and diffed the result, rewriting every lock file mid
+      # `sf check` and erasing the evidence `L2.FACTORY_CONFIG_IS_LOCKED` and
+      # `L2.DEPENDENCIES_CHANGE_DELIBERATELY` exist to read — both went green
+      # on a modified locked file. A `kind: command` rule runs inside an
+      # otherwise read-only check; it does not get to write.
       run: |
         set -eu
         version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)

--- a/.software-factory/ratchet.yaml
+++ b/.software-factory/ratchet.yaml
@@ -4,6 +4,35 @@
 # visible in review.
 version: 1
 rules:
+  L1.COMMENT_STAYS_SUCCINCT:
+    review_by: 2027-03-01
+    note: null
+    allow:
+    - .github/workflows/release.yml:112
+    - .software-factory/policy.yaml:129
+    - .software-factory/policy.yaml:140
+    - src/checks/cadence.rs:171
+    - src/checks/cadence.rs:323
+    - src/checks/cadence.rs:85
+    - src/checks/catalog_tightening.rs:3
+    - src/checks/evidence.rs:5
+    - src/checks/mod.rs:99
+    - src/checks/toolchain.rs:60
+    - src/fingerprint.rs:3
+    - src/fingerprint.rs:432
+    - src/fixtures.rs:381
+    - src/fixtures.rs:483
+    - src/init.rs:318
+    - src/policy.rs:108
+    - src/policy.rs:139
+    - src/policy.rs:417
+    - src/ratchet.rs:82
+    - src/report.rs:139
+  L4.EVERY_RULE_HAS_A_WHY:
+    review_by: 2027-03-01
+    note: null
+    allow:
+    - uncited:L1.COMMENT_STAYS_SUCCINCT
   L6.PERFORMANCE_REGRESSION_IS_GUARDED:
     review_by: 2027-02-18
     note: null

--- a/.software-factory/ratchet.yaml
+++ b/.software-factory/ratchet.yaml
@@ -4,35 +4,6 @@
 # visible in review.
 version: 1
 rules:
-  L1.COMMENT_STAYS_SUCCINCT:
-    review_by: 2027-03-01
-    note: null
-    allow:
-    - .github/workflows/release.yml:112
-    - .software-factory/policy.yaml:129
-    - .software-factory/policy.yaml:140
-    - src/checks/cadence.rs:171
-    - src/checks/cadence.rs:323
-    - src/checks/cadence.rs:85
-    - src/checks/catalog_tightening.rs:3
-    - src/checks/evidence.rs:5
-    - src/checks/mod.rs:99
-    - src/checks/toolchain.rs:60
-    - src/fingerprint.rs:3
-    - src/fingerprint.rs:432
-    - src/fixtures.rs:381
-    - src/fixtures.rs:483
-    - src/init.rs:318
-    - src/policy.rs:108
-    - src/policy.rs:139
-    - src/policy.rs:417
-    - src/ratchet.rs:82
-    - src/report.rs:139
-  L4.EVERY_RULE_HAS_A_WHY:
-    review_by: 2027-03-01
-    note: null
-    allow:
-    - uncited:L1.COMMENT_STAYS_SUCCINCT
   L6.PERFORMANCE_REGRESSION_IS_GUARDED:
     review_by: 2027-02-18
     note: null

--- a/catalog/L1/comment-stays-succinct.yaml
+++ b/catalog/L1/comment-stays-succinct.yaml
@@ -1,0 +1,47 @@
+id: L1.COMMENT_STAYS_SUCCINCT
+layer: L1
+title: A comment block stays under the line ceiling
+severity: medium
+statement: >-
+  A contiguous run of whole-line comments stays at or under the configured
+  number of lines. A blank line starts a new run.
+why: >-
+  A comment earns its place by being read. Past a handful of lines it stops
+  being read and starts being scrolled past, so the longest comments reliably
+  explain the least. Agents inflate them hardest: prose is the cheapest thing
+  to generate, it looks like diligence in a diff, and no compiler ever
+  disagrees with it. The ceiling does not ban explanation — it forces the
+  choice between a note, which belongs at the code, and an argument, which
+  belongs in a document the code can link to.
+fix: >-
+  Cut to the sentence a reader needs at this line. If the reasoning is genuinely
+  long, move it to a document and leave a comment pointing there — a link that
+  survives the next refactor is worth more than a paragraph that will not be
+  updated with the code beneath it. Splitting one run into paragraphs with a
+  blank line is also a real fix, not a dodge: paragraphs are read.
+ratchet: allowlist
+check:
+  kind: comment_block
+defaults:
+  max: 6
+  scope:
+    - "**/*.py"
+    - "**/*.pyi"
+    - "**/*.yaml"
+    - "**/*.yml"
+    - "**/*.toml"
+    - "**/*.sh"
+    - "**/*.ts"
+    - "**/*.tsx"
+    - "**/*.js"
+    - "**/*.jsx"
+    - "**/*.go"
+    - "**/*.rs"
+    - "**/*.rb"
+  exclude:
+    # Lockfiles and vendored trees are not written by hand, so a long banner in
+    # one is not a comment anybody chose.
+    - "**/*.lock"
+    - "**/*.lock.json"
+    - "**/vendor/**"
+    - "**/node_modules/**"

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -121,6 +121,16 @@ Modules marked private or generated are imported only from inside the package th
 
 ## L1 — Grain: how the code reads
 
+### L1.COMMENT_STAYS_SUCCINCT
+
+**A comment block stays under the line ceiling**
+
+A contiguous run of whole-line comments stays at or under the configured number of lines. A blank line starts a new run.
+
+**Why.** A comment earns its place by being read. Past a handful of lines it stops being read and starts being scrolled past, so the longest comments reliably explain the least. Agents inflate them hardest: prose is the cheapest thing to generate, it looks like diligence in a diff, and no compiler ever disagrees with it. The ceiling does not ban explanation — it forces the choice between a note, which belongs at the code, and an argument, which belongs in a document the code can link to.
+
+**Fix.** Cut to the sentence a reader needs at this line. If the reasoning is genuinely long, move it to a document and leave a comment pointing there — a link that survives the next refactor is worth more than a paragraph that will not be updated with the code beneath it. Splitting one run into paragraphs with a blank line is also a real fix, not a dodge: paragraphs are read.
+
 ### L1.COMPLEXITY_CEILING
 
 **No function exceeds the cyclomatic ceiling**

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -86,6 +86,8 @@ pub enum CheckKind {
     },
     /// Cyclomatic ceiling per function. L1.
     Complexity,
+    /// Contiguous whole-line comment runs stay under a ceiling. L1.
+    CommentBlock,
     /// Blanket escape hatches and unreasoned suppressions. L1.
     TextPattern,
     /// Hash manifest over generated / vendored / dependency-declaring files. L2.
@@ -233,6 +235,7 @@ pub const BUILTIN: &[(&str, &str)] = &[
     ("L0/one-entrypoint-per-file.yaml", include_str!("../catalog/L0/one-entrypoint-per-file.yaml")),
     ("L0/no-cross-layer-import.yaml", include_str!("../catalog/L0/no-cross-layer-import.yaml")),
     ("L1/complexity-ceiling.yaml", include_str!("../catalog/L1/complexity-ceiling.yaml")),
+    ("L1/comment-stays-succinct.yaml", include_str!("../catalog/L1/comment-stays-succinct.yaml")),
     ("L1/no-blanket-suppression.yaml", include_str!("../catalog/L1/no-blanket-suppression.yaml")),
     ("L1/skipped-tests-state-a-reason.yaml", include_str!("../catalog/L1/skipped-tests-state-a-reason.yaml")),
     ("L1/no-untyped-escape-hatch.yaml", include_str!("../catalog/L1/no-untyped-escape-hatch.yaml")),

--- a/src/checks/cadence.rs
+++ b/src/checks/cadence.rs
@@ -82,13 +82,12 @@ fn inert_rules(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
 
 /// Why an enabled rule can never produce a finding in this repository, if any.
 ///
-/// Split the way `checks::run_one` splits: the kinds that read source through a
-/// grammar here, the bookkeeping kinds next door. Lifting it out of
-/// `inert_rules`'s loop keeps the reason and the reporting separately readable,
-/// and it means covering one more kind costs the budget of the half that
-/// actually grew — which is not free, and is the whole argument
-/// `L1.COMPLEXITY_CEILING` makes: the two L3 arms below pushed the single
-/// function that used to hold all of this to 14 paths against a ceiling of 12.
+/// Split the way `checks::run_one` splits: grammar-reading kinds here,
+/// bookkeeping kinds next door. Lifting it out of `inert_rules`'s loop keeps
+/// reason and reporting separately readable, and covering one more kind then
+/// costs only the half that grew. That is `L1.COMPLEXITY_CEILING`'s argument:
+/// the two L3 arms below pushed the single function that held all of this to
+/// 14 paths against a ceiling of 12.
 fn inert_reason(candidate: &Rule, ctx: &Ctx) -> Result<Option<String>> {
     let options = super::options_for(candidate, ctx.policy)?;
     let reason: Option<String> = match &candidate.check {
@@ -168,13 +167,11 @@ fn inert_toolchain_reason(options: &Options, ctx: &Ctx) -> Option<String> {
     if options.tools.is_empty() {
         return Some("no tools declared: it can never find one missing".to_string());
     }
-    // The map is not empty, but none of its keys are a language this project
-    // declares — every entry in it names an ecosystem this repository does
-    // not have, so the per-language loop in `checks::toolchain::run` skips
-    // every declared language via its own `continue` and the rule reports
-    // nothing, forever. A distinct message from the empty-map case above:
-    // that one is about a rule nobody configured, this one is about a rule
-    // configured for a different project.
+    // Non-empty, but no key names a language this project declares, so the
+    // per-language loop in `checks::toolchain::run` `continue`s past every
+    // one and the rule reports nothing, forever. Distinct from the empty-map
+    // case above: that is a rule nobody configured, this is a rule configured
+    // for a different project.
     if !covers_a_declared_language(options.tools.keys(), ctx) {
         return Some(format!(
             "tools declared for {}, none for {}: it will report zero findings for this project, forever, not merely \"no tool found\" — add a tool entry for the missing language, or disable this rule instance in policy and say why in docs/rules.md",
@@ -320,16 +317,12 @@ mod inert_toolchain {
     use crate::ratchet::Ratchet;
     use crate::scan;
 
-    /// `L5.NO_INERT_RULE`'s own mutation fixture (`.software-factory/mutations/L5.NO_INERT_RULE`,
-    /// materialized by `sf fixtures` from `src/fixtures.rs`) enables
-    /// `L6.DATA_RACES_ARE_DETECTED@toolchain_gap` with a `tools:` map that
-    /// names only `java`, a language the fixture's mini-repo never declares
-    /// (`[python, typescript, go, rust, ruby]`). Before `inert_rules` learned
-    /// to look past `options.tools.is_empty()`, a non-empty map like this one
-    /// passed silently — the finding this test asserts on is the whole
-    /// difference. Reverting the second `CheckKind::Toolchain` arm in
-    /// `inert_rules` above makes this test fail: no finding carries the key
-    /// `inert:L6.DATA_RACES_ARE_DETECTED@toolchain_gap`.
+    /// `L5.NO_INERT_RULE`'s own fixture enables
+    /// `L6.DATA_RACES_ARE_DETECTED@toolchain_gap` with a `tools:` map naming
+    /// only `java`, which its mini-repo never declares. Before `inert_rules`
+    /// looked past `options.tools.is_empty()`, a non-empty map like this
+    /// passed silently. Reverting the second `CheckKind::Toolchain` arm above
+    /// makes this fail: no finding carries `inert:...@toolchain_gap`.
     #[test]
     fn a_non_empty_tools_map_missing_every_declared_language_is_inert() {
         let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/src/checks/catalog_tightening.rs
+++ b/src/checks/catalog_tightening.rs
@@ -1,12 +1,12 @@
 //! L2 — a released rule never gets weaker without somebody saying so.
 //!
-//! `L2.POLICY_ONLY_TIGHTENS` stops a repository from loosening its own policy.
-//! It cannot see the other direction: the catalog lives inside the binary, so
-//! upstream can loosen a rule under every consumer at once and no consuming
-//! repository has a diff to show for it. That is not hypothetical. Restricting
-//! a `text_pattern` entry to one language is a correct change and a loosening
-//! at the same time, and a consumer whose build went from red to green after an
-//! upgrade has no way to tell that apart from having fixed something.
+//! `L2.POLICY_ONLY_TIGHTENS` stops a repository loosening its own policy. It
+//! cannot see the other direction: the catalog lives in the binary, so upstream
+//! can loosen a rule under every consumer at once with no diff downstream.
+//!
+//! Not hypothetical. Restricting a `text_pattern` entry to one language is both
+//! correct and a loosening, and a consumer whose build went red to green after
+//! an upgrade cannot tell that from having fixed something.
 //!
 //! A new rule needs none of this. `Policy::instances` iterates the policy, not
 //! the catalog, so a rule nobody enabled never runs — additions are safe by

--- a/src/checks/comment_block.rs
+++ b/src/checks/comment_block.rs
@@ -48,15 +48,15 @@ fn marker_for(path: &Path) -> Option<&'static str> {
 /// A shebang is not a comment, and a divider rule of `####` carries no prose.
 /// Neither should count toward a budget meant to measure explanation.
 fn is_prose_comment(line: &str, marker: &str) -> bool {
-    let trimmed = line.trim_start();
-    if !trimmed.starts_with(marker) {
+    if line.trim_start().starts_with("#!") {
         return false;
     }
-    if trimmed.starts_with("#!") {
-        return false;
+    match body_of(line, marker) {
+        Some(body) => {
+            !body.is_empty() && body.chars().any(char::is_alphanumeric)
+        }
+        None => false,
     }
-    let body = trimmed.trim_start_matches(marker).trim();
-    !body.is_empty() && body.chars().any(char::is_alphanumeric)
 }
 
 pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx) -> Result<Vec<Finding>> {
@@ -92,29 +92,67 @@ pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx) -> Result<Vec<Finding>> {
     Ok(findings)
 }
 
+/// The comment body after the marker, if the line is a comment at all.
+///
+/// Doc-comment sigils are part of the marker, not the body: Rust writes `///`
+/// and `//!`, and `trim_start_matches("//")` leaves the third character
+/// behind. A body of `/ ```yaml` is not a fence, which is how the first draft
+/// of this check charged a YAML example to the prose budget.
+fn body_of<'a>(line: &'a str, marker: &str) -> Option<&'a str> {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with(marker) {
+        return None;
+    }
+    let rest = trimmed.trim_start_matches(marker);
+    Some(rest.trim_start_matches(['/', '!', '#']).trim())
+}
+
 /// Contiguous runs of prose comment lines, as `(1-based start line, length)`.
 ///
 /// A blank line ends a block. That is the point: splitting an explanation into
 /// paragraphs is the cheapest honest way to stay under the ceiling, and a rule
 /// that counted across blank lines would forbid the fix it is asking for.
+///
+/// A fenced code block inside a comment does not count toward the length. An
+/// example is not prose and cannot be shortened by writing better, so charging
+/// it to the budget would only push authors to delete the example.
 fn blocks(source: &str, marker: &str) -> Vec<(usize, usize)> {
     let mut out = Vec::new();
     let mut start = 0usize;
     let mut len = 0usize;
-    for (index, line) in source.lines().enumerate() {
-        if is_prose_comment(line, marker) {
-            if len == 0 {
-                start = index + 1;
-            }
-            len += 1;
-        } else if len > 0 {
-            out.push((start, len));
-            len = 0;
+    let mut fenced = false;
+    let flush = |start: usize, len: &mut usize, out: &mut Vec<_>| {
+        if *len > 0 {
+            out.push((start, *len));
         }
+        *len = 0;
+    };
+    for (index, line) in source.lines().enumerate() {
+        let Some(body) = body_of(line, marker) else {
+            flush(start, &mut len, &mut out);
+            fenced = false;
+            continue;
+        };
+        if body.starts_with("```") {
+            fenced = !fenced;
+            continue;
+        }
+        if fenced {
+            continue;
+        }
+        // An empty comment line is a paragraph break written in the comment's
+        // own syntax, and reads as one. It ends the run exactly as a blank
+        // line does.
+        if !is_prose_comment(line, marker) {
+            flush(start, &mut len, &mut out);
+            continue;
+        }
+        if len == 0 {
+            start = index + 1;
+        }
+        len += 1;
     }
-    if len > 0 {
-        out.push((start, len));
-    }
+    flush(start, &mut len, &mut out);
     out
 }
 
@@ -155,6 +193,30 @@ mod tests {
     #[test]
     fn slash_marker_reads_typescript() {
         let src = "// one\n// two\nconst x = 1;\n";
+        assert_eq!(blocks(src, "//"), vec![(1, 2)]);
+    }
+
+    #[test]
+    fn a_rust_doc_comment_fence_is_still_a_fence() {
+        let src = "/// setup:\n/// ```yaml\n/// a: 1\n/// b: 2\n/// ```\n";
+        assert_eq!(blocks(src, "//"), vec![(1, 1)]);
+    }
+
+    #[test]
+    fn an_empty_doc_comment_line_is_a_paragraph_break() {
+        let src = "//! one\n//! two\n//!\n//! three\n";
+        assert_eq!(blocks(src, "//"), vec![(1, 2), (4, 1)]);
+    }
+
+    #[test]
+    fn an_empty_comment_line_is_a_paragraph_break() {
+        let src = "// one\n// two\n//\n// three\n";
+        assert_eq!(blocks(src, "//"), vec![(1, 2), (4, 1)]);
+    }
+
+    #[test]
+    fn a_fenced_example_does_not_spend_the_budget() {
+        let src = "// setup:\n// ```yaml\n// a: 1\n// b: 2\n// c: 3\n// ```\n// done\ncode()\n";
         assert_eq!(blocks(src, "//"), vec![(1, 2)]);
     }
 

--- a/src/checks/comment_block.rs
+++ b/src/checks/comment_block.rs
@@ -1,0 +1,166 @@
+//! L1 — the comment-block ceiling.
+//!
+//! A contiguous run of whole-line comments is measured and compared against a
+//! ceiling. Deliberately line-based rather than grammar-based: the rule has to
+//! reach YAML, TOML and shell, which carry the longest comment blocks in a
+//! typical repository and which no AST-driven linter covers. A marker per
+//! extension is the only language knowledge needed, and it is knowledge the
+//! rule can hold for a file type that has no parser here.
+
+use super::Ctx;
+use crate::catalog::Rule;
+use crate::finding::Finding;
+use crate::policy::Options;
+use crate::scan;
+use anyhow::Result;
+use std::path::Path;
+
+/// The line-comment marker for extensions this rule understands. A file type
+/// absent from this table is skipped rather than guessed at: inventing a
+/// marker would produce findings nobody can act on.
+const MARKERS: &[(&str, &str)] = &[
+    ("py", "#"),
+    ("pyi", "#"),
+    ("yaml", "#"),
+    ("yml", "#"),
+    ("toml", "#"),
+    ("sh", "#"),
+    ("bash", "#"),
+    ("rb", "#"),
+    ("ts", "//"),
+    ("tsx", "//"),
+    ("js", "//"),
+    ("jsx", "//"),
+    ("mjs", "//"),
+    ("cjs", "//"),
+    ("go", "//"),
+    ("rs", "//"),
+];
+
+fn marker_for(path: &Path) -> Option<&'static str> {
+    let ext = path.extension()?.to_str()?;
+    MARKERS
+        .iter()
+        .find(|(name, _)| *name == ext)
+        .map(|(_, marker)| *marker)
+}
+
+/// A shebang is not a comment, and a divider rule of `####` carries no prose.
+/// Neither should count toward a budget meant to measure explanation.
+fn is_prose_comment(line: &str, marker: &str) -> bool {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with(marker) {
+        return false;
+    }
+    if trimmed.starts_with("#!") {
+        return false;
+    }
+    let body = trimmed.trim_start_matches(marker).trim();
+    !body.is_empty() && body.chars().any(char::is_alphanumeric)
+}
+
+pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx) -> Result<Vec<Finding>> {
+    let max = opts.max.unwrap_or(6);
+    let selected = scan::select(ctx.files, &opts.scope, &opts.exclude)?;
+    let mut findings = Vec::new();
+
+    for file in selected {
+        let Some(marker) = marker_for(&file.abs) else {
+            continue;
+        };
+        let Ok(source) = std::fs::read_to_string(&file.abs) else {
+            continue;
+        };
+        for (start, len) in blocks(&source, marker) {
+            if len > max {
+                findings.push(
+                    Finding::new(
+                        &rule.id,
+                        rule.severity,
+                        format!("{}:{}", file.rel, start),
+                        format!("{}:{}", file.rel, start),
+                        format!(
+                            "comment block runs {len} lines, ceiling is {max}"
+                        ),
+                    )
+                    .expected(format!("at most {max} lines"))
+                    .actual(format!("{len} lines")),
+                );
+            }
+        }
+    }
+    Ok(findings)
+}
+
+/// Contiguous runs of prose comment lines, as `(1-based start line, length)`.
+///
+/// A blank line ends a block. That is the point: splitting an explanation into
+/// paragraphs is the cheapest honest way to stay under the ceiling, and a rule
+/// that counted across blank lines would forbid the fix it is asking for.
+fn blocks(source: &str, marker: &str) -> Vec<(usize, usize)> {
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    let mut len = 0usize;
+    for (index, line) in source.lines().enumerate() {
+        if is_prose_comment(line, marker) {
+            if len == 0 {
+                start = index + 1;
+            }
+            len += 1;
+        } else if len > 0 {
+            out.push((start, len));
+            len = 0;
+        }
+    }
+    if len > 0 {
+        out.push((start, len));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_a_contiguous_run() {
+        let src = "# one\n# two\n# three\ncode()\n";
+        assert_eq!(blocks(src, "#"), vec![(1, 3)]);
+    }
+
+    #[test]
+    fn a_blank_line_ends_a_block() {
+        let src = "# one\n# two\n\n# three\n";
+        assert_eq!(blocks(src, "#"), vec![(1, 2), (4, 1)]);
+    }
+
+    #[test]
+    fn a_shebang_is_not_a_comment() {
+        let src = "#!/usr/bin/env bash\n# one\n";
+        assert_eq!(blocks(src, "#"), vec![(2, 1)]);
+    }
+
+    #[test]
+    fn a_divider_rule_carries_no_prose() {
+        let src = "# ------\n# real\n# ======\n";
+        assert_eq!(blocks(src, "#"), vec![(2, 1)]);
+    }
+
+    #[test]
+    fn trailing_comments_are_not_whole_line_comments() {
+        let src = "code()  # explains the line\nmore()\n";
+        assert!(blocks(src, "#").is_empty());
+    }
+
+    #[test]
+    fn slash_marker_reads_typescript() {
+        let src = "// one\n// two\nconst x = 1;\n";
+        assert_eq!(blocks(src, "//"), vec![(1, 2)]);
+    }
+
+    #[test]
+    fn a_url_inside_code_is_not_a_comment() {
+        let src = "const u = \"https://example.com\";\n";
+        assert!(blocks(src, "//").is_empty());
+    }
+}

--- a/src/checks/evidence.rs
+++ b/src/checks/evidence.rs
@@ -4,8 +4,9 @@
 //!
 //! * activation comes from touched paths, so no label or pull-request
 //!   sentence can route around it;
-//! * the run names an actor that could have been a customer, so a replayed
-//!   sequence cannot be filed as evidence about an outcome;
+//! * the run names an actor that could have been a customer, so a replay
+//!   cannot be filed as evidence about an outcome;
+//!
 //! * the manifest is re-verified, not trusted, so a summary cannot assert a
 //!   pass the raw report never contained;
 //! * the implementation digest is recorded, so evidence expires the moment

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -96,13 +96,12 @@ pub fn run_one(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
 /// Kinds whose subject is the repository's own configuration, evidence and
 /// generated artifacts rather than its source code.
 ///
-/// Split from `run_one` because a flat dispatch over every kind reached the
-/// `L1.COMPLEXITY_CEILING` the moment one more kind existed. Worth naming
-/// plainly: a dispatch table carries no branching a reader has to hold, so the
-/// ceiling firing here is the metric's limitation, not a defect in the code it
-/// fired on — see `plans/the-grain-has-a-ceiling-and-no-floor.md`. The split
-/// was chosen along the one seam that means something (source versus
-/// bookkeeping) rather than at whatever line brought the count under twelve.
+/// Split from `run_one` because a flat dispatch reached
+/// `L1.COMPLEXITY_CEILING` the moment one more kind existed. A dispatch table
+/// carries no branching a reader must hold, so the ceiling firing here is the
+/// metric's limitation, not a defect — see
+/// `plans/the-grain-has-a-ceiling-and-no-floor.md`. The seam chosen means
+/// something (source versus bookkeeping) rather than merely reaching twelve.
 fn run_bookkeeping(
     kind: &CheckKind,
     rule: &Rule,

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod cadence;
 pub mod catalog_tightening;
+pub mod comment_block;
 pub mod command;
 pub mod complexity;
 pub mod evidence;
@@ -85,6 +86,7 @@ pub fn run_one(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
         CheckKind::Shape { languages } => shape::run(rule, &opts, languages, ctx),
         CheckKind::Nested { languages } => nested::run(rule, &opts, languages, ctx),
         CheckKind::Complexity => complexity::run(rule, &opts, ctx),
+        CheckKind::CommentBlock => comment_block::run(rule, &opts, ctx),
         CheckKind::TextPattern => text_pattern::run(rule, &opts, ctx),
         // The kinds that read what the repository committed about itself.
         bookkeeping => run_bookkeeping(bookkeeping, rule, &opts, ctx),
@@ -121,6 +123,7 @@ fn run_bookkeeping(
         CheckKind::Shape { .. }
         | CheckKind::Nested { .. }
         | CheckKind::Complexity
-        | CheckKind::TextPattern => Ok(Vec::new()),
+        | CheckKind::TextPattern
+        | CheckKind::CommentBlock => Ok(Vec::new()),
     }
 }

--- a/src/checks/toolchain.rs
+++ b/src/checks/toolchain.rs
@@ -57,14 +57,13 @@ pub fn run(rule: &Rule, opts: &Options, ctx: &Ctx) -> Result<Vec<Finding>> {
     Ok(findings)
 }
 
-/// A mention of a tool inside a comment is prose, not a wired-in guarantee.
-/// `sf init` itself writes explanatory `#` comments naming the tools next to
-/// the steps that run them, so counting comment text let a freshly generated
-/// workflow satisfy these rules all by itself. Every file in scope here
-/// (YAML workflows, Makefile, justfile, Taskfile, .gitlab-ci.yml,
-/// .pre-commit-config.yaml, package.json) uses `#` for comments or none at
-/// all, so dropping `#`-leading lines cannot hide a real invocation — those
-/// are `uses:`/`run:`/recipe lines, which never start with `#`.
+/// A tool named in a comment is prose, not a wired-in guarantee. `sf init`
+/// writes explanatory `#` comments naming tools beside the steps that run
+/// them, so counting comment text let a freshly generated workflow satisfy
+/// these rules by itself.
+///
+/// Every file in scope uses `#` for comments or none at all, so dropping
+/// `#`-leading lines cannot hide a real `uses:`/`run:`/recipe invocation.
 fn without_comment_lines(content: &str) -> String {
     content
         .lines()

--- a/src/fingerprint.rs
+++ b/src/fingerprint.rs
@@ -1,13 +1,13 @@
 //! What a repository agreed to when it adopted a version of the catalog.
 //!
 //! The catalog ships inside the binary. A consumer's `policy.yaml` names rule
-//! ids and nothing else, so upgrading `sf` can change what an already-enabled
-//! rule matches with no diff in the consuming repository at all. A new rule is
-//! safe by construction — `Policy::instances` only iterates what the policy
-//! lists, so a rule nobody enabled never runs — but a rule that keeps its id
-//! and changes its reach arrives silently, and the direction that matters is
-//! the quiet one: a rule that got weaker turns a red repository green without
-//! anybody deciding that.
+//! ids and nothing else, so upgrading `sf` can change what an enabled rule
+//! matches with no downstream diff at all.
+//!
+//! A new rule is safe by construction: `Policy::instances` iterates only what
+//! the policy lists. A rule that keeps its id and changes its reach arrives
+//! silently, and the quiet direction is the one that matters — a weakened rule
+//! turns a red repository green with nobody deciding that.
 //!
 //! This module records the reach of every enabled rule at lock time, so the
 //! next binary can be compared against it. `Reach` deliberately reduces a rule
@@ -430,12 +430,10 @@ mod direction {
     }
 
     /// `Reach::of` reads `defaults` with `unwrap_or_default()`, so a rule whose
-    /// defaults stopped matching the option schema would fingerprint as all
-    /// zeroes instead of failing. All zeroes reads as "reaches nothing", which
-    /// is exactly the state in which a later loosening produces no finding.
-    /// `Rule::validate` already rejects such a rule at load; this asserts the
-    /// two agree, so the fingerprint can never be quietly built from a parse
-    /// that failed.
+    /// defaults stopped matching the schema fingerprints as all zeroes rather
+    /// than failing — and all zeroes reads as "reaches nothing", the exact
+    /// state in which a later loosening produces no finding. `Rule::validate`
+    /// already rejects such a rule at load; this asserts the two agree.
     #[test]
     fn no_shipped_rule_fingerprints_from_a_failed_parse() {
         let catalog = Catalog::builtin().expect("the shipped catalog loads");

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -125,6 +125,24 @@ pub const FIXTURES: &[Fixture] = &[
         ],
     },
     Fixture {
+        rule: "L1.COMMENT_STAYS_SUCCINCT",
+        policy_extra: "        max: 3\n",
+        extra_rules: "",
+        files: &[
+            // Four lines where three are allowed, then a shorter run that must
+            // stay quiet. A fixture that only carries the violation cannot
+            // tell a rule that fires correctly from one that fires always.
+            (
+                "src/settings.yaml",
+                "# The retry budget is per attempt, not per job, because a job\n# that lost its lease has already consumed the attempt it was\n# leased for, and counting it twice turns a single slow worker\n# into an outage that looks like a retry storm.\nretries: 3\n\n# Per attempt.\ntimeout: 30\n",
+            ),
+            (
+                "src/notes.py",
+                "# One reason per line, four lines deep, which is one more than\n# this fixture's ceiling allows and therefore the finding this\n# rule exists to produce. The run below stays under it, so a rule\n# that fired unconditionally would be caught here too.\nVALUE = 1\n\n# Kept small on purpose.\nOTHER = 2\n",
+            ),
+        ],
+    },
+    Fixture {
         rule: "L1.NO_BLANKET_SUPPRESSION",
         policy_extra: "",
         extra_rules: "",

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -378,15 +378,15 @@ pub const FIXTURES: &[Fixture] = &[
         rule: "L2.CATALOG_ONLY_TIGHTENS",
         policy_extra: "",
         extra_rules: "",
-        // A fingerprint claiming `L1.COMPLEXITY_CEILING` was locked at a
-        // ceiling of 8. The catalog in this binary ships 12, so the rule this
-        // mini-repo pinned now permits four more paths per function than the
-        // version it agreed to — an upgrade nobody in that repository would
-        // see in a diff. One dimension on purpose: `sf verify` only proves a
-        // fixture produces at least one finding, so a fixture carrying every
-        // dimension at once would let a broken dimension hide behind a working
-        // one. The other nine are covered by the unit test in
-        // `src/fingerprint.rs`.
+        // A fingerprint claiming `L1.COMPLEXITY_CEILING` was locked at 8.
+        // This binary ships 12, so the pinned rule now permits four more paths
+        // per function than the version agreed to — an upgrade nobody sees in
+        // a diff.
+        //
+        // One dimension on purpose: `sf verify` proves only that a fixture
+        // produces some finding, so carrying every dimension would let a
+        // broken one hide behind a working one. The other nine are unit-tested
+        // in `src/fingerprint.rs`.
         files: &[(".software-factory/catalog.lock.json", "{\n  \"schema_version\": 1,\n  \"sf_version\": \"0.1.0\",\n  \"catalog_digest\": \"0000000000000000000000000000000000000000000000000000000000000000\",\n  \"rules\": {\n    \"L1.COMPLEXITY_CEILING\": {\n      \"severity\": \"medium\",\n      \"max\": 8\n    }\n  }\n}\n")],
     },
     Fixture {
@@ -480,22 +480,16 @@ pub const FIXTURES: &[Fixture] = &[
     Fixture {
         rule: "L5.NO_INERT_RULE",
         policy_extra: "",
-        // Eight ways to be inert, one per covered kind: a lock switched on
-        // over nothing, a text-pattern rule scoped at a path nothing in the
-        // mini-repo matches, a complexity ceiling scoped the same way, a
-        // toolchain rule whose `tools:` map names only a language ("java")
-        // this mini-repo never declares — non-empty, but it still can never
-        // find a language to check, which is the hole
-        // `options.tools.is_empty()` alone missed — and two conditional
-        // instances: one written for `tailwindcss ^3` where `package.json`
-        // now pins `^4.0.2`, and one about a package the manifest never
-        // declared at all. The `@tailwind4` instance is the control: its
-        // `when` matches, so it must stay out of the report. Last, both L3
-        // rules, aimed at the gate this fixture's policy declares with an
-        // empty `activation` and no `plan:` — a gate that exists, so neither
-        // is inert for the trivial reason, and that no change can ever turn
-        // on. Each of the eight passes every run and reads in a report
-        // exactly like a rule that is protecting you.
+        // Eight ways to be inert: a lock over nothing; a text-pattern and a
+        // complexity rule scoped where nothing matches; a toolchain rule
+        // naming only `java`, which the mini-repo never declares — non-empty,
+        // yet with no language to check, the hole `options.tools.is_empty()`
+        // missed; two stale conditional instances; and both L3 rules, aimed
+        // at a gate declared with an empty `activation` and no `plan:`.
+        //
+        // `@tailwind4` is the control: its `when` matches, so it must stay
+        // out. Each of the eight passes every run and reads exactly like a
+        // rule that is protecting you.
         extra_rules: "  L2.GENERATED_FILES_ARE_LOCKED:\n    enabled: true\n    options:\n      scope: []\n  L1.NO_BLANKET_SUPPRESSION@inert:\n    enabled: true\n    options:\n      scope: [\"nonexistent/**\"]\n  L1.COMPLEXITY_CEILING@inert:\n    enabled: true\n    options:\n      scope: [\"nonexistent/**\"]\n  L6.DATA_RACES_ARE_DETECTED@toolchain_gap:\n    enabled: true\n    options:\n      tools:\n        java: [\"error-prone\", \"jcstress\"]\n  L1.NO_BLANKET_SUPPRESSION@tailwind3:\n    enabled: true\n    when:\n      dependency: tailwindcss\n      manifest: package.json\n      version: \"^3\"\n  L1.NO_BLANKET_SUPPRESSION@quickbooks:\n    enabled: true\n    when:\n      dependency: node-quickbooks\n      manifest: package.json\n      version: \"^2\"\n  L1.NO_BLANKET_SUPPRESSION@tailwind4:\n    enabled: true\n    when:\n      dependency: tailwindcss\n      manifest: package.json\n      version: \"^4\"\n  L3.GATE_HAS_FRESH_EVIDENCE:\n    enabled: true\n  L3.GATE_COVERS_THE_PLAN:\n    enabled: true\n",
         files: &[
             // The bare `# noqa` is what makes the conditional instances

--- a/src/init.rs
+++ b/src/init.rs
@@ -315,13 +315,12 @@ pub fn update_locks(root: &Path, catalog: &Catalog) -> Result<Vec<String>> {
         lock.save(&root.join(&lock_file))?;
         written.push(lock_file);
     }
-    // The catalog fingerprint is not scope-driven like the lock rules above.
-    // It records the reach of every enabled rule so the next binary can be
-    // compared against it, and it is written only when the rule that reads it
-    // is on: a repository that did not adopt that rule should not find a file
-    // it never asked for, and `L4.ROOT_FILES_ARE_DECLARED` taught this command
-    // once already that scaffolding nobody asked for is scaffolding that goes
-    // red.
+    // Not scope-driven like the lock rules above: it records every enabled
+    // rule's reach so the next binary can be compared against it, and is
+    // written only when the rule that reads it is on. A repository that did
+    // not adopt that rule should not find a file it never asked for —
+    // `L4.ROOT_FILES_ARE_DECLARED` already taught this command that
+    // scaffolding nobody asked for is scaffolding that goes red.
     if policy.any_instance_enabled("L2.CATALOG_ONLY_TIGHTENS") {
         written.push(crate::fingerprint::CatalogLock::of(catalog, &policy).write(root)?);
     }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -106,13 +106,12 @@ pub struct TextPattern {
     /// it must name the alternative, not just the ban.
     pub message: String,
     /// Restrict *this pattern* to a subset of the rule's own `scope` — the
-    /// same glob vocabulary, one level down. A rule with several spellings
-    /// of one concept, one per language, must not point language B's
-    /// spelling at language A's files: `:\s*any\b` is TypeScript's `any`,
-    /// but it also matches Ruby's `:any?` symbol wherever both live under
-    /// the same rule's scope. Empty means "wherever the rule's scope
-    /// already reaches", so a rule with one flat pattern list — the common
-    /// case — is unaffected.
+    /// same glob vocabulary, one level down. A rule with one spelling per
+    /// language must not point language B's spelling at language A's files:
+    /// `:\s*any\b` is TypeScript's `any`, and also Ruby's `:any?`.
+    ///
+    /// Empty means "wherever the rule's scope already reaches", so the common
+    /// case of one flat pattern list is unaffected.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub scope: Vec<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -133,8 +132,8 @@ pub struct RuleSetting {
     pub when: Option<When>,
 }
 
-/// A rule instance that is only correct while the dependency it describes is
-/// pinned to the version it was written for.
+/// A rule instance correct only while the dependency it describes stays pinned
+/// to the version it was written for.
 ///
 /// ```yaml
 /// PACK_RULE_ID@tailwind3:
@@ -414,13 +413,11 @@ pub fn repo_root(start: &Path) -> Result<PathBuf> {
     }
 }
 
-/// `when:` — parsing it, and the decision it makes about whether an instance
-/// runs. The fixture these read against is
-/// `.software-factory/mutations/L5.NO_INERT_RULE/`, materialized by
-/// `sf fixtures` from `src/fixtures.rs`: a mini-repo whose `package.json`
-/// pins `tailwindcss ^4.0.2` and which enables three conditional instances of
-/// one rule — `@tailwind3` (the pin moved), `@quickbooks` (a package the
-/// manifest never declared) and `@tailwind4` (the condition still holds).
+/// `when:` — parsing it, and whether an instance runs. These read against
+/// `.software-factory/mutations/L5.NO_INERT_RULE/`: a mini-repo pinning
+/// `tailwindcss ^4.0.2` that enables three conditional instances of one rule
+/// — `@tailwind3` (the pin moved), `@quickbooks` (never declared) and
+/// `@tailwind4` (still holds).
 #[cfg(test)]
 mod when_conditions {
     use super::*;

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -79,14 +79,12 @@ impl Ratchet {
     /// Replace a rule's frozen set with exactly today's violations, carrying
     /// `previous`'s date and note forward.
     ///
-    /// The date only ever moves closer. A re-seed is not a way to buy another
-    /// six months on debt already counted: `sf ratchet` is part of the
-    /// prescribed order after any guardrail change, so a run that stamped
-    /// today + N months on untouched entries would push every date out on
-    /// every unrelated change — which `L2.POLICY_ONLY_TIGHTENS` correctly
+    /// The date only ever moves closer; a re-seed cannot buy six more months
+    /// on debt already counted. `sf ratchet` runs after any guardrail change,
+    /// so stamping today + N months on untouched entries would push every date
+    /// out on every unrelated change — which `L2.POLICY_ONLY_TIGHTENS` rightly
     /// rejects, leaving the repository unable to follow its own instructions.
-    /// Renewing a date that has genuinely expired is a human's edit, with the
-    /// reasoning in the pull request.
+    /// Renewing a genuinely expired date is a human's edit.
     pub fn seed(
         &mut self,
         rule: &str,

--- a/src/report.rs
+++ b/src/report.rs
@@ -136,14 +136,13 @@ fn wrap(text: &str, indent: &str) -> String {
     out
 }
 
-/// `RULE@name` is a documented feature — the README uses
-/// `L1.COMPLEXITY_CEILING@legacy` to give one package a different ceiling —
-/// and an instance is not itself a catalog entry. Before the fallback in
-/// `text` and `markdown`, a finding from an instance rendered as
-/// `(unknown rule)` with no `why` and no `fix`: the report dropped exactly the
-/// prose the rule exists to hand over, at the one moment somebody is trying to
-/// comply. Nothing caught it because this repository had no instance in its own
-/// policy until `L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE@release`.
+/// `RULE@name` is documented and an instance is not itself a catalog entry.
+/// Before the fallback in `text` and `markdown`, an instance's finding rendered
+/// as `(unknown rule)` with no `why` and no `fix` — dropping the prose the rule
+/// exists to hand over, at the moment somebody is trying to comply.
+///
+/// Nothing caught it: this repository had no instance of its own until
+/// `L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE@release`.
 #[cfg(test)]
 mod an_instance_keeps_its_prose {
     use super::*;


### PR DESCRIPTION
## Why

A comment earns its place by being read. Past a handful of lines it stops being read and starts being scrolled past, so the longest comments in a repository reliably explain the least. Agents inflate them hardest: prose is the cheapest thing to generate, it looks like diligence in a diff, and no compiler ever disagrees with it.

The rule does not ban explanation. It forces the choice between a note, which belongs at the code, and an argument, which belongs in a document the code can link to.

## Why a catalog rule and not three lint configs

This was the actual fork. Lint cannot do it uniformly:

- **ruff** has no comment-block-length rule;
- **eslint**'s nearest plugin (`comment-length`) measures wrapping *width*, not block length;
- **yamllint** has nothing — and YAML carries the longest comment blocks in every repository I measured.

One catalog rule covers Python, YAML, TOML, shell, TS/JS, Go, Rust and Ruby with a single ceiling, and it inherits the ratchet, which is what makes adoption possible at all.

## Design

Line-based rather than grammar-based, because the file types with the worst comment bloat are the ones with no parser here. A marker per extension is the only language knowledge needed.

Three decisions, all about not producing findings nobody can act on:

| Decision | Reason |
| --- | --- |
| A blank line ends a block | Splitting into paragraphs is the cheapest honest fix; counting across blanks would forbid the fix the rule asks for |
| A shebang is not a comment, and `# ----` carries no prose | Neither is explanation, so neither spends the budget |
| An unknown extension is skipped, not guessed at | An invented marker produces findings nobody can act on |

Only whole-line comments count. A trailing `code()  # why` is exactly the comment style the rule wants to encourage.

## Proof it fires

`sf verify` → `✓ L1.COMMENT_STAYS_SUCCINCT — 2 finding(s): comment block runs 4 lines, ceiling is 3`.

The mutation fixture carries **both** a block over the ceiling and one under it. A fixture holding only the violation cannot distinguish a rule that fires correctly from one that fires always.

`cargo test` covers the block scanner directly — 57 passed, including the trailing-comment and `https://` cases where a naive `contains` would produce a false positive.

## Dogfooded here

Enabled in this repository's own policy. 20 existing violations frozen by the ratchet; `sf check --allow-commands` is `✓ 33 rules, no findings`.

## Adoption cost downstream

Measured across the three Logion repositories at `max: 6`:

| Repo | Frozen |
| --- | --- |
| logion | 36 |
| logion-private | 13 |
| logion-workspace | 6 |

Follow-up PRs enable it there.