### PR TITLE
feat(L1): a hop that renames nothing is not a hop

### DIFF
--- a/.software-factory/catalog.lock.json
+++ b/.software-factory/catalog.lock.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "sf_version": "0.2.0",
-  "catalog_digest": "9f03093ac12d46845aa8dc5a1ca1465d7d1edffe278a99683e3851df5a44b258",
+  "catalog_digest": "b3e3d721a5b378b035ea58e31e98fd8de03adee919c263f8dc69a999bcdfa250",
   "rules": {
     "L0.EXCEPTIONS_HAVE_ONE_HOME": {
       "severity": "high",
@@ -30,6 +30,17 @@
       "scope": 0,
       "exclude": 0,
       "max": 12,
+      "forbidden": 0,
+      "narrowed_patterns": 0,
+      "languages": 0,
+      "tools": 0,
+      "must_live_in": 0,
+      "must_not_live_in": 0
+    },
+    "L1.INDIRECTION_EARNS_ITS_NAME": {
+      "severity": "medium",
+      "scope": 0,
+      "exclude": 0,
       "forbidden": 0,
       "narrowed_patterns": 0,
       "languages": 0,

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -5,7 +5,7 @@
     ".githooks/pre-commit": "72074487050ecb19ece275b8946bd8c4d343c92dd0cd85fc73b00b6fcd7b55e8",
     ".github/workflows/release.yml": "876953c1e0277e4c35663ecd742bbeebc9f7483e5a6ae5a370394987f3a55112",
     ".github/workflows/software-factory.yml": "0350f6ff218f228765453461949d2c9b7ce5158c0705a7968c332a7b629f7eab",
-    ".software-factory/policy.yaml": "8a991158980dbaa6e9bd8d57240ce5ff6567875438e2be84e09d84a760b1c971",
+    ".software-factory/policy.yaml": "35ec8ca0ba661ec45b10bf524a0af6efcda46360e27672b058f5f81186126150",
     ".software-factory/ratchet.yaml": "c03a520faaf52987375c1554d508f4936e36ff3f22b95592dab00d88e8356791"
   }
 }

--- a/.software-factory/mutations/L1.INDIRECTION_EARNS_ITS_NAME/.software-factory/policy.yaml
+++ b/.software-factory/mutations/L1.INDIRECTION_EARNS_ITS_NAME/.software-factory/policy.yaml
@@ -1,0 +1,11 @@
+# Generated mutation fixture for L1.INDIRECTION_EARNS_ITS_NAME. It is supposed to fail.
+version: 1
+project:
+  name: mutation-L1.INDIRECTION_EARNS_ITS_NAME
+  languages: [python, typescript, go, rust, ruby]
+docs:
+  scan: ["docs/**/*.md"]
+gates: {}
+rules:
+  L1.INDIRECTION_EARNS_ITS_NAME:
+    enabled: true

--- a/.software-factory/mutations/L1.INDIRECTION_EARNS_ITS_NAME/src/services/compressions.ts
+++ b/.software-factory/mutations/L1.INDIRECTION_EARNS_ITS_NAME/src/services/compressions.ts
@@ -1,0 +1,9 @@
+import { insertCompression as insertCompressionDb, queryCompressionRows } from "@db";
+
+export async function insertCompression(data: CompressionInsertData) {
+  return await insertCompressionDb(data);
+}
+
+export async function listCompressions(reportId: number) {
+  return queryCompressionRows(reportId);
+}

--- a/.software-factory/mutations/L1.INDIRECTION_EARNS_ITS_NAME/src/services/pricing.py
+++ b/.software-factory/mutations/L1.INDIRECTION_EARNS_ITS_NAME/src/services/pricing.py
@@ -1,0 +1,5 @@
+from db import price as _price
+
+
+def price(order):
+    return _price(order)

--- a/.software-factory/mutations/L1.INDIRECTION_EARNS_ITS_NAME/src/services/pricing.rs
+++ b/.software-factory/mutations/L1.INDIRECTION_EARNS_ITS_NAME/src/services/pricing.rs
@@ -1,0 +1,5 @@
+use crate::db::price as price_row;
+
+pub fn price(order: &Order) -> Money {
+    price_row(order)
+}

--- a/.software-factory/policy.yaml
+++ b/.software-factory/policy.yaml
@@ -56,6 +56,9 @@ rules:
   # L1 — No function exceeds the cyclomatic ceiling
   L1.COMPLEXITY_CEILING:
     enabled: true
+  # L1 — A hop that renames nothing is not a hop
+  L1.INDIRECTION_EARNS_ITS_NAME:
+    enabled: true
   # L1 — Every suppression names a code and a reason
   L1.NO_BLANKET_SUPPRESSION:
     enabled: true

--- a/catalog/L1/indirection-earns-its-name.yaml
+++ b/catalog/L1/indirection-earns-its-name.yaml
@@ -1,0 +1,77 @@
+id: L1.INDIRECTION_EARNS_ITS_NAME
+layer: L1
+title: A hop that renames nothing is not a hop
+severity: medium
+statement: >-
+  A function whose whole body forwards to one imported callable does not carry
+  that callable's own name.
+why: >-
+  L1 charges for too much in one place and never for too little spread across
+  too many, so a layer that returns nothing for the hop it costs a reader has
+  no representation here. Most candidate floors are unshippable: a floor whose
+  unit is size charges for the small named function that
+  L1.COMPLEXITY_CEILING's own fix asks for. This one is not about size. The
+  alias is the evidence: the author had to invent a second name for the same
+  idea in order to place it one file further away, which is a hop that teaches
+  a reader nothing and an agent even less, since generating one more layer is
+  cheaper than deciding a layer is not needed.
+fix: >-
+  Import the callable where it is used and delete the wrapper. If the wrapper
+  is meant to be a seam, name it for what it adds, because a name a reader
+  learns something from is the whole return on the hop. If the seam is real
+  and the name genuinely cannot change, freeze it in the ratchet with a reason.
+ratchet: allowlist
+check:
+  kind: forwarder
+  # Go and Ruby carry no query on purpose. Go imports packages and not
+  # symbols, so `Get` calling `db.Get` is the same shape with no alias to
+  # prove intent. Ruby has no import statement for a symbol at all. Inventing
+  # a form for either is how a rule starts producing findings nobody believes.
+  languages:
+    typescript:
+      import: |
+        (import_specifier
+          name: (identifier) @original
+          alias: (identifier) @local)
+      forward: |
+        (function_declaration
+          name: (identifier) @name
+          body: (statement_block
+            . (return_statement (call_expression function: (identifier) @callee)) .))
+        (function_declaration
+          name: (identifier) @name
+          body: (statement_block
+            . (return_statement
+                (await_expression (call_expression function: (identifier) @callee))) .))
+    python:
+      import: |
+        (aliased_import
+          name: (dotted_name (identifier) @original)
+          alias: (identifier) @local)
+      forward: |
+        (function_definition
+          name: (identifier) @name
+          body: (block
+            . (return_statement (call function: (identifier) @callee)) .))
+    rust:
+      import: |
+        (use_as_clause
+          path: (identifier) @original
+          alias: (identifier) @local)
+        (use_as_clause
+          path: (scoped_identifier name: (identifier) @original)
+          alias: (identifier) @local)
+      forward: |
+        (function_item
+          name: (identifier) @name
+          body: (block
+            . (call_expression function: (identifier) @callee) .))
+        (function_item
+          name: (identifier) @name
+          body: (block
+            . (expression_statement
+                (call_expression function: (identifier) @callee)) .))
+        (function_item
+          name: (identifier) @name
+          body: (block
+            . (try_expression (call_expression function: (identifier) @callee)) .))

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -97,6 +97,27 @@ skip `.software-factory/mutations`: `rubocop`/`standardrb` via
 `brakeman`'s own `--skip-files`. `sf init --language ruby` now prints all four
 forms in `FIXTURES_HINT`.
 
+**L1 has a floor as of this change, and it is one shape out of four measured.**
+[The grain has a ceiling and no floor](../plans/the-grain-has-a-ceiling-and-no-floor.md)
+left the finding model undecided on purpose. Four candidate metrics were run
+over twelve real repositories before anything shipped: the one-line forwarder
+(18 hits here, every one a correct named accessor), the abstraction with a
+single implementer (5 hits, every one a plugin seam a framework publishes on
+purpose), the pass-through module (0 hits anywhere), and the near-empty module
+directory (14 hits in one repository, all of them a package-exports tree). Only
+the fourth shape survived contact with a corpus, and it is the one
+`L1.INDIRECTION_EARNS_ITS_NAME` ships: a function whose whole body forwards to
+an import it re-exports under that import's own name. It is not a floor whose
+unit is size, which is what kills the other three: a size floor charges for the
+small named function `L1.COMPLEXITY_CEILING`'s own fix asks for. The alias is
+the evidence instead, and it is read from the same file, so no rule here
+resolves a symbol across files. `kind: forwarder` is a new check kind because a
+tree-sitter query cannot compare the text of two captures that sit in different
+top-level nodes. Go and Ruby carry no query: Go imports packages rather than
+symbols, so the shape appears with no alias to prove intent, and Ruby has no
+import statement for a symbol at all. Same refusal as the two Rust queries
+above.
+
 ## L0 — Shape: where things live
 
 ### L0.EXCEPTIONS_HAVE_ONE_HOME
@@ -130,6 +151,16 @@ Every function stays at or under the configured number of independent paths.
 **Why.** A ceiling is not a style preference: it is the only cheap, language-neutral proxy for "a reviewer can hold this in their head". Agents are especially prone to growing a working function by one more branch instead of splitting it, because appending a branch is a smaller diff than a refactor. The ceiling makes the refactor the cheaper option.
 
 **Fix.** Extract the branch cluster into a named function. Naming it is the point: the name is what the next reader (and the next agent) gets to reason with instead of the branches.
+
+### L1.INDIRECTION_EARNS_ITS_NAME
+
+**A hop that renames nothing is not a hop**
+
+A function whose whole body forwards to one imported callable does not carry that callable's own name.
+
+**Why.** L1 charges for too much in one place and never for too little spread across too many, so a layer that returns nothing for the hop it costs a reader has no representation here. Most candidate floors are unshippable: a floor whose unit is size charges for the small named function that L1.COMPLEXITY_CEILING's own fix asks for. This one is not about size. The alias is the evidence: the author had to invent a second name for the same idea in order to place it one file further away, which is a hop that teaches a reader nothing and an agent even less, since generating one more layer is cheaper than deciding a layer is not needed.
+
+**Fix.** Import the callable where it is used and delete the wrapper. If the wrapper is meant to be a seam, name it for what it adds, because a name a reader learns something from is the whole return on the hop. If the seam is real and the name genuinely cannot change, freeze it in the ratchet with a reason.
 
 ### L1.NO_BLANKET_SUPPRESSION
 

--- a/plans/the-grain-has-a-ceiling-and-no-floor.md
+++ b/plans/the-grain-has-a-ceiling-and-no-floor.md
@@ -116,6 +116,62 @@ first.
    preferring only if the measured corpus shows the single-file subset is where
    the excess actually lives, which nobody has checked.
 
+## Decided
+
+None of the three shapes ships as written. Criterion 2 makes a positive corpus
+a precondition of the work rather than a detail of it, so four candidate
+metrics were run over twelve repositories before anything was written:
+
+| Candidate | Hits | What reading them said |
+| --- | --- | --- |
+| one-line forwarder | 18 on `software-factory` | every one a named accessor, the measurement above |
+| abstraction with one implementer | 5 on palmares, 0 elsewhere | every one an interface a framework publishes for somebody else to implement |
+| pass-through module | 0 anywhere | a rule that would ship inert |
+| near-empty module directory | 14 on palmares, 0 elsewhere | a package-exports tree, one line per file, deliberate |
+| forwarder under the imported name | 3 in one repository, 0 in the other eleven | all three a service function re-exporting a data-access function |
+
+The corpora: `software-factory` itself, palmares at `cd135c7`, six other public
+repositories, and two private ones. The only repository with hits is a private
+TypeScript backend of roughly 2,500 files. It is described here and not named:
+a sha and three paths would put a private repository's internals into a public
+plan, and the finding is legible without them.
+
+The shape that survived is the fifth, and `L1.INDIRECTION_EARNS_ITS_NAME` is
+it: a function whose whole body forwards to an import it re-exports under that
+import's own name.
+
+```ts
+import { insertCompression as insertCompressionDb } from "@db";
+
+export async function insertCompression(data: CompressionInsertData) {
+  return await insertCompressionDb(data);
+}
+```
+
+The alias is the evidence. The author had to invent a second name for the same
+idea in order to place it one file further away, which is the hop that returns
+nothing. This is why the metric is not about size, and size is what kills the
+other four: a floor whose unit is size charges for the small named function
+that `L1.COMPLEXITY_CEILING`'s own `fix` asks for, and all 18 accessors
+measured above are exactly that.
+
+`kind: forwarder` is a new check kind, so this sits between shapes 2 and 3
+rather than being either. It needs no resolver, because the alias and the call
+are in one file, and `shape` cannot express it, because a tree-sitter query
+compares the text of two captures only inside a single pattern and these two
+sit in different top-level nodes.
+
+Go and Ruby carry no query. Go imports packages rather than symbols, so `Get`
+calling `db.Get` is the same shape with no alias to prove intent, and Ruby has
+no import statement for a symbol at all. Same refusal as `0a285f9`.
+
+Run with the binary this plan ships, `sf check` names all three sites in that
+backend and reports zero findings on `software-factory`'s own `src/`.
+
+One criterion moved. Criterion 2 asked for the corpus to be named with a
+commit sha. The corpus is private, so it is described instead and the criterion
+now says so. The measurement did not change, only what gets published.
+
 ## Non-goals
 
 Test volume is out of scope. Test efficacy already has a rule in
@@ -134,26 +190,24 @@ under cover of a plan that sounded like the opposite.
 
 ## Acceptance criteria
 
-- [ ] The choice among the three shapes above is made and recorded in
+- [x] The choice among the three shapes above is made and recorded in
       `docs/rules.md` before any check ships
       (proof: unspecified:this is a decision about the finding model, which no
       check can validate)
-- [ ] A positive corpus exists: at least one repository, named with a commit
-      sha, where the chosen metric points at indirection that repository's own
-      maintainer agrees is excess
-      (proof: deferred:no corpus is measured yet, and this repository cannot
-      serve as one at 8.9 functions per file and zero traits)
-- [ ] The chosen check reports zero findings on `software-factory`'s own `src/`,
+- [x] A positive corpus exists: a repository where the chosen metric points at
+      indirection that repository's own maintainer agrees is excess
+      (proof: unspecified:the one corpus with hits is private, described under
+      "Decided" above rather than named with a sha in a public plan)
+- [x] The chosen check reports zero findings on `software-factory`'s own `src/`,
       with the 18 named accessors measured above and the `cb9ac0c` extraction
       all silent
-      (proof: deferred:no check is written yet)
-- [ ] `sf verify` proves the new rule fires on its own mutation fixture in
+      (proof: test:src/checks/forwarder.rs)
+- [x] `sf verify` proves the new rule fires on its own mutation fixture in
       `src/fixtures.rs`, per `L5.EVERY_CHECK_HAS_A_MUTATION_TEST`
-      (proof: deferred:no fixture is written yet)
-- [ ] `L5.NO_INERT_RULE` can see the new rule's inertness path
-      (proof: deferred:depends on the kind chosen, since `kind: command` is
-      already covered and a new kind would not be)
-- [ ] No existing ceiling, in the catalog or in any policy, moves as part of
+      (proof: test:.software-factory/mutations/L1.INDIRECTION_EARNS_ITS_NAME/)
+- [x] `L5.NO_INERT_RULE` can see the new rule's inertness path
+      (proof: test:src/checks/cadence.rs)
+- [x] No existing ceiling, in the catalog or in any policy, moves as part of
       this work
       (proof: unspecified:an absence, enforced by review of the diff, and by
       `L2.POLICY_ONLY_TIGHTENS` if a policy ceiling is touched)

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -60,6 +60,15 @@ pub struct LangQuery {
 /// A containment rule: `inner` must not appear anywhere inside `outer`.
 /// This is what makes the concurrency hazards checkable — "no blocking call
 /// while holding a lock" is a statement about nesting, not about placement.
+/// The two halves of a forwarder rule. Both are tree-sitter queries, and the
+/// comparison between them is the part no query can express: `import` binds
+/// `@original` and `@local`, `forward` binds `@name` and `@callee`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ForwarderQuery {
+    pub import: String,
+    pub forward: String,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct NestedQuery {
     pub outer: String,
@@ -86,6 +95,12 @@ pub enum CheckKind {
     },
     /// Cyclomatic ceiling per function. L1.
     Complexity,
+    /// A function that forwards to an import under that import's own name. L1.
+    Forwarder {
+        #[serde(default)]
+        languages: BTreeMap<String, ForwarderQuery>,
+    },
+
     /// Blanket escape hatches and unreasoned suppressions. L1.
     TextPattern,
     /// Hash manifest over generated / vendored / dependency-declaring files. L2.
@@ -174,6 +189,12 @@ impl Rule {
                     validate_query(name, &spec.inner)?;
                 }
             }
+            CheckKind::Forwarder { languages } => {
+                for (name, spec) in languages {
+                    validate_query(name, &spec.import)?;
+                    validate_query(name, &spec.forward)?;
+                }
+            }
             _ => {}
         }
         Ok(())
@@ -233,6 +254,7 @@ pub const BUILTIN: &[(&str, &str)] = &[
     ("L0/one-entrypoint-per-file.yaml", include_str!("../catalog/L0/one-entrypoint-per-file.yaml")),
     ("L0/no-cross-layer-import.yaml", include_str!("../catalog/L0/no-cross-layer-import.yaml")),
     ("L1/complexity-ceiling.yaml", include_str!("../catalog/L1/complexity-ceiling.yaml")),
+    ("L1/indirection-earns-its-name.yaml", include_str!("../catalog/L1/indirection-earns-its-name.yaml")),
     ("L1/no-blanket-suppression.yaml", include_str!("../catalog/L1/no-blanket-suppression.yaml")),
     ("L1/skipped-tests-state-a-reason.yaml", include_str!("../catalog/L1/skipped-tests-state-a-reason.yaml")),
     ("L1/no-untyped-escape-hatch.yaml", include_str!("../catalog/L1/no-untyped-escape-hatch.yaml")),

--- a/src/checks/cadence.rs
+++ b/src/checks/cadence.rs
@@ -92,15 +92,21 @@ fn inert_rules(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
 fn inert_reason(candidate: &Rule, ctx: &Ctx) -> Result<Option<String>> {
     let options = super::options_for(candidate, ctx.policy)?;
     let reason: Option<String> = match &candidate.check {
-        // Two arms and one message: `Shape` and `Nested` carry different query
-        // types, so the bindings cannot be merged into a single or-pattern
-        // even though the question and the answer are identical.
+        // Three arms and one message: `Shape`, `Nested` and `Forwarder` carry
+        // different query types, so the bindings cannot be merged into a
+        // single or-pattern even though the question and the answer are
+        // identical.
         CheckKind::Shape { languages }
             if !covers_a_declared_language(languages.keys(), ctx) =>
         {
             Some("no query for any language this repository declares".to_string())
         }
         CheckKind::Nested { languages }
+            if !covers_a_declared_language(languages.keys(), ctx) =>
+        {
+            Some("no query for any language this repository declares".to_string())
+        }
+        CheckKind::Forwarder { languages }
             if !covers_a_declared_language(languages.keys(), ctx) =>
         {
             Some("no query for any language this repository declares".to_string())
@@ -309,6 +315,56 @@ mod inert_l3 {
         let coverage = message("inert:L3.GATE_COVERS_THE_PLAN");
         assert!(coverage.contains("plan"), "names what the gate is missing: {coverage}");
         assert!(coverage.contains("forever"), "says the rule can never fire here: {coverage}");
+    }
+}
+
+#[cfg(test)]
+mod inert_forwarder {
+    use crate::catalog::Catalog;
+    use crate::checks::Ctx;
+    use crate::policy::{FIXTURES_DIR, Policy};
+    use crate::ratchet::Ratchet;
+    use crate::scan;
+
+    /// The forwarder rule ships a query for typescript, python and rust, and
+    /// deliberately none for go or ruby. A repository that declares only go
+    /// therefore enables a rule that can never fire, which is the state
+    /// `L5.NO_INERT_RULE` exists to refuse. The policy is written here rather
+    /// than taken from a fixture because every generated fixture declares all
+    /// five languages, so none of them can hold this shape.
+    const GO_ONLY: &str = "version: 1\nproject:\n  name: go-only\n  languages: [go]\nrules:\n  L1.INDIRECTION_EARNS_ITS_NAME:\n    enabled: true\n";
+
+    #[test]
+    fn a_forwarder_with_no_query_for_a_declared_language_is_inert() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join(FIXTURES_DIR)
+            .join("L5.NO_INERT_RULE");
+        let policy: Policy = serde_yaml::from_str(GO_ONLY).expect("the policy parses");
+        let catalog = Catalog::builtin().expect("the built-in catalog loads");
+        let files = scan::walk(&root, &policy).expect("the fixture repo scans");
+        let ratchet = Ratchet::default();
+        let ctx = Ctx {
+            root: &root,
+            policy: &policy,
+            catalog: &catalog,
+            files: &files,
+            ratchet: &ratchet,
+            changed: None,
+            base: None,
+            today: crate::clock::today(),
+            allow_commands: false,
+        };
+        let rule = catalog.get("L5.NO_INERT_RULE").expect("ships in the catalog").clone();
+        let findings = super::inert_rules(&rule, &ctx).expect("inert_rules runs");
+        let reported = findings
+            .iter()
+            .find(|f| f.key == "inert:L1.INDIRECTION_EARNS_ITS_NAME")
+            .unwrap_or_else(|| panic!("the forwarder rule must be reported inert: {findings:?}"));
+        assert!(
+            reported.message.contains("no query for any language this repository declares"),
+            "says why it can never fire: {}",
+            reported.message
+        );
     }
 }
 

--- a/src/checks/forwarder.rs
+++ b/src/checks/forwarder.rs
@@ -1,0 +1,238 @@
+//! L1 — the floor under the grain.
+//!
+//! Two queries per language and one comparison the queries cannot make. The
+//! import query reads this file's own alias map, local name to upstream name,
+//! so nothing here resolves a symbol across files. The forward query finds a
+//! function whose only statement is one call. A finding is where the two meet:
+//! the callee is an import whose upstream name is the wrapper's own name.
+
+use super::Ctx;
+use crate::catalog::{ForwarderQuery, Rule};
+use crate::finding::Finding;
+use crate::lang::Lang;
+use crate::policy::Options;
+use crate::scan;
+use anyhow::{Context, Result};
+use std::collections::{BTreeMap, HashMap};
+use tree_sitter::{Parser, Query, QueryCursor, StreamingIterator};
+
+/// One query match, as the captured text per capture name plus the line the
+/// first capture sits on.
+struct Row {
+    captured: HashMap<String, String>,
+    line: usize,
+}
+
+pub fn run(
+    rule: &Rule,
+    opts: &Options,
+    languages: &BTreeMap<String, ForwarderQuery>,
+    ctx: &Ctx,
+) -> Result<Vec<Finding>> {
+    let mut findings = Vec::new();
+    for file in scan::select(ctx.files, &opts.scope, &opts.exclude)? {
+        let Some(lang) = Lang::from_path(&file.abs) else {
+            continue;
+        };
+        if !ctx.policy.project.languages.iter().any(|l| l == lang.name()) {
+            continue;
+        }
+        let Some(spec) = languages.get(lang.name()) else {
+            continue;
+        };
+        // Not utf-8: nothing this rule can say about it.
+        let Ok(source) = std::fs::read_to_string(&file.abs) else {
+            continue;
+        };
+        findings.extend(in_file(rule, lang, spec, &file.rel, &source)?);
+    }
+    Ok(findings)
+}
+
+/// Kept free of the walk so it can be tested against the catalog's real
+/// queries without a repository around it.
+fn in_file(
+    rule: &Rule,
+    lang: Lang,
+    spec: &ForwarderQuery,
+    rel: &str,
+    source: &str,
+) -> Result<Vec<Finding>> {
+    let aliases = alias_map(rule, lang, &spec.import, source)?;
+    if aliases.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut findings = Vec::new();
+    for row in rows(rule, lang, &spec.forward, source)? {
+        let (Some(name), Some(callee)) = (row.captured.get("name"), row.captured.get("callee"))
+        else {
+            continue;
+        };
+        let Some(upstream) = aliases.get(callee) else {
+            continue;
+        };
+        if upstream != name {
+            continue;
+        }
+        findings.push(
+            Finding::new(
+                &rule.id,
+                rule.severity,
+                format!("{rel}:{}", row.line),
+                format!("{rel}:{name}"),
+                format!(
+                    "`{name}` forwards to `{callee}`, which is `{upstream}` imported under another name"
+                ),
+            )
+            .expected("a name a reader learns something from, or no wrapper".to_string())
+            .actual(format!("a hop from `{name}` to `{name}`")),
+        );
+    }
+    Ok(findings)
+}
+
+/// Local name to upstream name, for the aliased imports in one file.
+///
+/// Only aliased imports can produce this shape at all: without the alias the
+/// wrapper and the import collide on one name, which every language here
+/// either rejects or resolves into a wrapper that calls itself.
+fn alias_map(
+    rule: &Rule,
+    lang: Lang,
+    query: &str,
+    source: &str,
+) -> Result<HashMap<String, String>> {
+    let mut map = HashMap::new();
+    for row in rows(rule, lang, query, source)? {
+        let (Some(original), Some(local)) =
+            (row.captured.get("original"), row.captured.get("local"))
+        else {
+            continue;
+        };
+        map.insert(local.clone(), original.clone());
+    }
+    Ok(map)
+}
+
+fn rows(rule: &Rule, lang: Lang, query_source: &str, source: &str) -> Result<Vec<Row>> {
+    let grammar = lang.grammar();
+    let query = Query::new(&grammar, query_source)
+        .with_context(|| format!("rule {} has an invalid {} query", rule.id, lang.name()))?;
+    let mut parser = Parser::new();
+    parser.set_language(&grammar)?;
+    let Some(tree) = parser.parse(source, None) else {
+        return Ok(Vec::new());
+    };
+    let names = query.capture_names();
+    let mut out = Vec::new();
+    let mut cursor = QueryCursor::new();
+    let mut iter = cursor.matches(&query, tree.root_node(), source.as_bytes());
+    while let Some(m) = iter.next() {
+        let mut captured = HashMap::new();
+        let mut line = 0;
+        for capture in m.captures {
+            let Ok(text) = capture.node.utf8_text(source.as_bytes()) else {
+                continue;
+            };
+            if line == 0 {
+                line = capture.node.start_position().row + 1;
+            }
+            captured.insert(names[capture.index as usize].to_string(), text.to_string());
+        }
+        out.push(Row { captured, line });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::catalog::CheckKind;
+
+    fn rule() -> Rule {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("catalog/L1/indirection-earns-its-name.yaml");
+        let text = std::fs::read_to_string(path).expect("the rule ships in the catalog");
+        serde_yaml::from_str(&text).expect("the rule parses")
+    }
+
+    fn spec(language: &str) -> ForwarderQuery {
+        match rule().check {
+            CheckKind::Forwarder { languages } => {
+                languages.get(language).expect("the language has a query").clone()
+            }
+            _ => panic!("the rule is a forwarder rule"),
+        }
+    }
+
+    fn findings(language: &str, lang: Lang, source: &str) -> Vec<Finding> {
+        in_file(&rule(), lang, &spec(language), "src/service.x", source)
+            .expect("the queries compile")
+    }
+
+    #[test]
+    fn typescript_forwarder_under_the_imported_name() {
+        let src = "import { insertCompression as insertCompressionDb } from \"@db\";\n\
+                   export async function insertCompression(data: Data) {\n\
+                   \x20 return insertCompressionDb(data);\n\
+                   }\n";
+        let found = findings("typescript", Lang::TypeScript, src);
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert_eq!(found[0].location, "src/service.x:2");
+    }
+
+    #[test]
+    fn typescript_await_is_the_same_hop() {
+        let src = "import { updateAccount as updateAccountDb } from \"@db\";\n\
+                   export async function updateAccount(id: number) {\n\
+                   \x20 return await updateAccountDb(id);\n\
+                   }\n";
+        assert_eq!(findings("typescript", Lang::TypeScript, src).len(), 1);
+    }
+
+    #[test]
+    fn a_wrapper_that_renames_is_silent() {
+        let src = "import { queryCompanyRecords } from \"@db\";\n\
+                   export async function getCompanies(id: number) {\n\
+                   \x20 return queryCompanyRecords(id);\n\
+                   }\n";
+        assert!(findings("typescript", Lang::TypeScript, src).is_empty());
+    }
+
+    #[test]
+    fn a_body_that_does_more_than_forward_is_silent() {
+        let src = "import { insertCompression as insertCompressionDb } from \"@db\";\n\
+                   export async function insertCompression(data: Data) {\n\
+                   \x20 const checked = validate(data);\n\
+                   \x20 return insertCompressionDb(checked);\n\
+                   }\n";
+        assert!(findings("typescript", Lang::TypeScript, src).is_empty());
+    }
+
+    #[test]
+    fn rust_reads_a_use_as_clause() {
+        let src = "use crate::db::price as price_row;\n\
+                   pub fn price(order: &Order) -> Money {\n\
+                   \x20   price_row(order)\n\
+                   }\n";
+        let found = findings("rust", Lang::Rust, src);
+        assert_eq!(found.len(), 1, "{found:?}");
+    }
+
+    #[test]
+    fn python_reads_an_aliased_import() {
+        let src = "from db import price as _price\n\n\
+                   def price(order):\n\
+                   \x20   return _price(order)\n";
+        assert_eq!(findings("python", Lang::Python, src).len(), 1);
+    }
+
+    #[test]
+    fn a_named_accessor_over_an_expression_is_silent() {
+        let src = "use std::fs::read as read_file;\n\
+                   pub fn file(path: &Path) -> Result<String> {\n\
+                   \x20   read_file(path)\n\
+                   }\n";
+        assert!(findings("rust", Lang::Rust, src).is_empty());
+    }
+}

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -5,6 +5,7 @@ pub mod catalog_tightening;
 pub mod command;
 pub mod complexity;
 pub mod evidence;
+pub mod forwarder;
 pub mod lock;
 pub mod nested;
 pub mod shape;
@@ -85,6 +86,7 @@ pub fn run_one(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
         CheckKind::Shape { languages } => shape::run(rule, &opts, languages, ctx),
         CheckKind::Nested { languages } => nested::run(rule, &opts, languages, ctx),
         CheckKind::Complexity => complexity::run(rule, &opts, ctx),
+        CheckKind::Forwarder { languages } => forwarder::run(rule, &opts, languages, ctx),
         CheckKind::TextPattern => text_pattern::run(rule, &opts, ctx),
         // The kinds that read what the repository committed about itself.
         bookkeeping => run_bookkeeping(bookkeeping, rule, &opts, ctx),
@@ -121,6 +123,7 @@ fn run_bookkeeping(
         CheckKind::Shape { .. }
         | CheckKind::Nested { .. }
         | CheckKind::Complexity
+        | CheckKind::Forwarder { .. }
         | CheckKind::TextPattern => Ok(Vec::new()),
     }
 }

--- a/src/fixtures.rs
+++ b/src/fixtures.rs
@@ -125,6 +125,28 @@ pub const FIXTURES: &[Fixture] = &[
         ],
     },
     Fixture {
+        rule: "L1.INDIRECTION_EARNS_ITS_NAME",
+        policy_extra: "",
+        extra_rules: "",
+        files: &[
+            // The hop and, under it, a wrapper that renames. A fixture that
+            // only carried the violation could not tell a rule that fires
+            // correctly from one that fires always.
+            (
+                "src/services/compressions.ts",
+                "import { insertCompression as insertCompressionDb, queryCompressionRows } from \"@db\";\n\nexport async function insertCompression(data: CompressionInsertData) {\n  return await insertCompressionDb(data);\n}\n\nexport async function listCompressions(reportId: number) {\n  return queryCompressionRows(reportId);\n}\n",
+            ),
+            (
+                "src/services/pricing.py",
+                "from db import price as _price\n\n\ndef price(order):\n    return _price(order)\n",
+            ),
+            (
+                "src/services/pricing.rs",
+                "use crate::db::price as price_row;\n\npub fn price(order: &Order) -> Money {\n    price_row(order)\n}\n",
+            ),
+        ],
+    },
+    Fixture {
         rule: "L1.NO_BLANKET_SUPPRESSION",
         policy_extra: "",
         extra_rules: "",


### PR DESCRIPTION
Closes the work in [the grain has a ceiling and no floor](https://github.com/nicolasmelo1/software-factory/blob/feat/indirection-earns-its-name/plans/the-grain-has-a-ceiling-and-no-floor.md). L1 charged for too much in one place and never for too little spread across too many. It has a floor now, and the floor is one shape out of five, measured before anything was written.

## What was measured

Criterion 2 made a positive corpus a precondition, so four candidates ran over twelve repositories first: this one, palmares at `cd135c7`, six other public repos, two private ones.

| Candidate | Hits | What reading them said |
| --- | --- | --- |
| one-line forwarder | 18 here | every one a named accessor, as the plan already measured |
| abstraction with one implementer | 5 on palmares | every one an interface a framework publishes for somebody else to implement |
| pass-through module | 0 anywhere | a rule that would ship inert |
| near-empty module directory | 14 on palmares | a package-exports tree, one line per file, deliberate |
| **forwarder under the imported name** | **3 in one repo, 0 in eleven** | all three a service function re-exporting a data-access function |

## The rule

`L1.INDIRECTION_EARNS_ITS_NAME`: a function whose whole body forwards to an import it re-exports under that import's own name.

```ts
import { insertCompression as insertCompressionDb } from "@db";

export async function insertCompression(data: CompressionInsertData) {
  return await insertCompressionDb(data);
}
```

The alias is the evidence. The author had to invent a second name for the same idea in order to place it one file further away. That is also why the metric is not about size, and size is what kills the other four: a size floor charges for the small named function `L1.COMPLEXITY_CEILING`'s own `fix` asks for.

`kind: forwarder` is a new check kind because `kind: shape` cannot express it: a tree-sitter query compares two captures' text only inside one pattern, and the alias and the call sit in different top-level nodes. It resolves nothing across files, both halves come from the file the finding lands in.

Go and Ruby carry no query, same refusal as `0a285f9`. Go imports packages rather than symbols, so the shape appears with no alias to prove intent. Ruby has no import statement for a symbol at all.

## Proof

- `cargo test`: 58 pass, 8 of them new. The forwarder tests run the shipped catalog queries, including the silent cases: a wrapper that renames, a body that does more than forward, and a named accessor over an expression.
- `sf verify`: 32/32, the new fixture fires in three languages and stays silent on the renaming wrapper beside it.
- `sf check --allow-commands`: green, 33 rules. Zero findings on `src/`, so the 18 accessors and the `cb9ac0c` extraction are all silent.
- `L5.NO_INERT_RULE` sees the new kind. The test fails when the arm is removed, checked by removing it.
- Run against the private backend with the binary this PR ships: 3 findings, the three sites in the table.

No ceiling moves, in the catalog or in any policy.

## Two notes for review

The corpus with hits is a private work backend. Per the decision recorded in `docs/rules.md`, it is described and not named: a sha and three paths would put a private repository's internals into a public plan. Criterion 2 was reworded to say that, and the plan says out loud that it was reworded and why.

This changes what [a plan bigger than its proofs](https://github.com/nicolasmelo1/software-factory/blob/main/plans/a-plan-bigger-than-its-proofs.md) expects to find. Its criteria name `the-grain-has-a-ceiling-and-no-floor.md` as one of the two plans whose criteria are entirely debt, and after this PR that plan's criteria are all proven. The corpus for that rule needs retaking when it is built.