### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/.software-factory/catalog.lock.json
+++ b/.software-factory/catalog.lock.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "sf_version": "0.2.0",
+  "sf_version": "0.3.0",
   "catalog_digest": "2d97bfc6f0df6991b1453257f3242219b3524132cdc7d64d8a80828da8de1265",
   "rules": {
     "L0.EXCEPTIONS_HAVE_ONE_HOME": {

--- a/.software-factory/locks/dependencies.lock.json
+++ b/.software-factory/locks/dependencies.lock.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "files": {
-    "Cargo.lock": "940b0ac872a684908214087a515451552e75fa2c372cc74304cba66a4dfaa768",
-    "Cargo.toml": "8dd434a7835e9f504b8141ce967a0dc62b2dddaa5e9636d880e88d2097812502"
+    "Cargo.lock": "7d16a7c5742810f4be4352cf4c2d7cbfeef6e6c7362d7ba2135d518a7005a4da",
+    "Cargo.toml": "ecc22b605b453007e4f65dddcce58971f8c0c54024c982636ced713263d5e393"
   }
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "sf"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sf"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ chmod +x sf-aarch64-apple-darwin && mv sf-aarch64-apple-darwin ~/.local/bin/sf
 Or build it, if you have cargo:
 
 ```sh
-cargo install --git https://github.com/nicolasmelo1/software-factory --tag v0.2.0 --locked
+cargo install --git https://github.com/nicolasmelo1/software-factory --tag v0.3.0 --locked
 ```
 
 **Pin the tag.** The rule catalog ships *inside* the binary, so tracking the
@@ -64,7 +64,7 @@ writes the same pinned form into the CI workflow it generates.
 version number alone does not identify the rules:
 
 ```
-sf 0.2.0 (catalog ddde87d963b7, 35 rules)
+sf 0.3.0 (catalog 2d97bfc6f0df, 37 rules)
 ```
 
 One static binary, no runtime, nothing to clone. Building it is a single


### PR DESCRIPTION
Six PRs since `v0.2.0`, twelve days ago. The tag is the only thing a consumer can pin, so none of this exists downstream until it lands.

## Why minor and not patch

Three changes can turn a consumer's green build red with nothing moving in their repository:

- `L5.NO_INERT_RULE` gained arms for the L3 kinds (`153ccf4`). A repository with both L3 rules on and `gates: {}` now gets a finding instead of silence.
- A tool named only in a comment no longer satisfies the hazard rules (`e853b41`).
- `L3.GATE_HAS_FRESH_EVIDENCE` now reads `actor` against a denylist, so a manifest crediting the harness is refused.

Patch means an upgrade nobody has to think about. This is not that.

The two new L1 rules, `L1.COMMENT_STAYS_SUCCINCT` and `L1.INDIRECTION_EARNS_ITS_NAME`, do not enter that argument. `Policy::instances` iterates the policy and not the catalog, so a rule nobody enabled never runs. That is what `checks::catalog_tightening` means when it says additions are safe by construction.

## Why not 1.0

1.0 is a promise about rule ids, and [a gate bigger than its proofs](https://github.com/nicolasmelo1/software-factory/blob/main/plans/a-gate-bigger-than-its-proofs.md) has an open decision about splitting `L3.GATE_HAS_FRESH_EVIDENCE` into one rule or three. Promising id stability the week before renaming one is the wrong order.

## What moved

`Cargo.toml`, `Cargo.lock` and the README's `--tag`, which is what the release gate compares. `sf lock` then records the two, since `Cargo.toml` and `Cargo.lock` are under `L2.DEPENDENCIES_CHANGE_DELIBERATELY`.

The README's sample output moves too: it claimed `sf 0.2.0 (catalog ddde87d963b7, 35 rules)` and the catalog is at 37 with a different digest. Nothing checks that line, which is exactly why it drifted.

Release notes are generated by `release.yml` from `sf --version` and `sf catalog`, so there is no changelog to write here.

## Proof

`cargo test` 69 pass, `sf verify --allow-commands` 33/33, `sf check --allow-commands` green with 34 rules, and the version consistency command in `L2.DERIVED_ARTIFACTS_MATCH_THEIR_SOURCE@release` passes against the rebuilt binary reporting `sf 0.3.0 (catalog 2d97bfc6f0df, 37 rules)`.

After merge, tag `v0.3.0` on main to trigger the release workflow.