### PR TITLE
docs(plans): the gate assumes a way to run the product

### DIFF
--- a/plans/next-steps.md
+++ b/plans/next-steps.md
@@ -10,19 +10,21 @@ precondition exists. Park it in the second table rather than deleting it.
 | --- | --- | --- |
 | 1 | [Adoption is proven end to end](adoption-is-proven-end-to-end.md) | `L3.GATE_HAS_FRESH_EVIDENCE` is active on this repository against a sealed run of `sf init` on a codebase nobody tuned it for, and goes red the next time `src/init.rs` changes without the run being repeated. |
 
-| 2 | [Expand the language adapters](expand-language-adapters.md) | A repo in a new language runs `sf init`, `sf verify` is green, and `sf check` finds something a maintainer of that language agrees is real. |
+| 2 | [The gate assumes a way to run the product](the-gate-assumes-a-way-to-run-the-product.md) | This repository's `adoption` evidence comes from a harness the tool generated, the gate is sealed against it and `sf check` is green, and the same generator run against a repository nobody tuned it for writes a harness whose report goes red when that product is broken. |
 
-| 3 | [The four L0 structural rules assume an import statement](structural-rules-assume-an-import-statement.md) | `sf check` on a Rails repository with `languages: [ruby]` reports a real cross-layer finding read from a constant reference rather than a `require` statement, with zero findings on Rails' own base-class inheritance. |
+| 3 | [Expand the language adapters](expand-language-adapters.md) | A repo in a new language runs `sf init`, `sf verify` is green, and `sf check` finds something a maintainer of that language agrees is real. |
 
-| 4 | [The grain has a ceiling and no floor](the-grain-has-a-ceiling-and-no-floor.md) | `sf check` on a repository nobody tuned it for names at least one indirection site whose own maintainer agrees should not exist, and stays silent on `software-factory`'s own `src/`, where every candidate hit measured so far is correct code. |
+| 4 | [The four L0 structural rules assume an import statement](structural-rules-assume-an-import-statement.md) | `sf check` on a Rails repository with `languages: [ruby]` reports a real cross-layer finding read from a constant reference rather than a `require` statement, with zero findings on Rails' own base-class inheritance. |
 
-| 5 | [A plan bigger than its proofs](a-plan-bigger-than-its-proofs.md) | `sf check` on this repository names the two plans whose criteria are entirely debt and the one plan with no criteria at all, stays silent on `rules-activate-by-dependency-version.md`, and `sf verify` proves the rule fires on both a floor fixture and a ceiling fixture. |
+| 5 | [The grain has a ceiling and no floor](the-grain-has-a-ceiling-and-no-floor.md) | `sf check` on a repository nobody tuned it for names at least one indirection site whose own maintainer agrees should not exist, and stays silent on `software-factory`'s own `src/`, where every candidate hit measured so far is correct code. |
 
-| 6 | [A gate bigger than its proofs](a-gate-bigger-than-its-proofs.md) | A gate requiring no assertions, over a report carrying none, with an emptied goal denylist, turns `sf check` red, and this repository's own `adoption` gate stays green. |
+| 6 | [A plan bigger than its proofs](a-plan-bigger-than-its-proofs.md) | `sf check` on this repository names the two plans whose criteria are entirely debt and the one plan with no criteria at all, stays silent on `rules-activate-by-dependency-version.md`, and `sf verify` proves the rule fires on both a floor fixture and a ceiling fixture. |
+
+| 7 | [A gate bigger than its proofs](a-gate-bigger-than-its-proofs.md) | A gate requiring no assertions, over a report carrying none, with an emptied goal denylist, turns `sf check` red, and this repository's own `adoption` gate stays green. |
 
 
 ## Parked
 
 | Work | Waiting on |
 | --- | --- |
-| [Rule packs for third-party APIs and libraries](third-party-rule-packs.md) | Version-conditional activation (#2). A pack that cannot say which upstream version it describes is a pack somebody has to remember to remove, which is the state it exists to fix. |
+| [Rule packs for third-party APIs and libraries](third-party-rule-packs.md) | Version-conditional activation (#3). A pack that cannot say which upstream version it describes is a pack somebody has to remember to remove, which is the state it exists to fix. |

--- a/plans/the-gate-assumes-a-way-to-run-the-product.md
+++ b/plans/the-gate-assumes-a-way-to-run-the-product.md
@@ -1,0 +1,165 @@
+# The gate assumes a way to run the product
+
+L3 verifies a report of a run against the real thing. Nothing in `sf` produces
+that run, and nothing checks that a way to produce it exists.
+
+The five properties `docs/method.md` claims for L3 are all properties of the
+report: it is re-hashed, its assertions are re-checked, its digest expires, its
+goal and actor are read for leaked answers. Every one of them starts after
+somebody has already got the product running. That step is the expensive one,
+and it is the one the tool says nothing about.
+
+## Measured
+
+- `sf init` writes `gates: {}` into every policy it scaffolds
+  (`src/init.rs:367`). An adopter who enables L3 gets an empty map and no first
+  gate.
+- The interview's thirteen decisions never mention L3 or a gate
+  (`interview/decisions.yaml`). There is no answer that turns the layer on, so
+  the only route to a gate is hand-writing four things at once: the policy
+  entry, the manifest, the report, and whatever produced the report.
+- `skills/factory-evidence/SKILL.md` step 3 is the entire product surface for
+  producing a run: "Start the actual entry point a customer would use. Drive it
+  the way they would."
+- One worked example exists anywhere, and it is in this repository:
+  `.software-factory/evidence/adoption-scenario.sh`, 4.5 KB of shell. Nothing
+  generated it, nothing regenerates it, and no rule reads it. It is a file we
+  happen to keep.
+
+So the layer that exists to prove the product works assumes a way to run the
+product, and ships none. We solved that once, by hand, for ourselves. An
+adopter meets it as a sentence in a skill.
+
+## Prior art
+
+pstack ships `create-verification-skill`: it interviews the codebase and writes
+`.claude/skills/verify-<app>/SKILL.md` carrying launch, doctor, drive, evidence
+and cleanup, plus a `features/` directory with one file per user-facing feature
+and its observable success criteria, then runs the loop once to prove what it
+wrote works. On a multi-tenant application it reportedly worked out how to start
+Clerk locally, create an account, an app and an instance, and carried on from
+there.
+
+Two things there are right for us and one is not.
+
+**Right: the discovery is expensive and belongs in the repository.** Working out
+how to bring a multi-tenant stack up is a half hour that should be spent once,
+not once per run. Redoing it per run is also the incentive that produces a
+beautifully written report of a run that never happened.
+
+**Right: a feature with an observable success criterion is the same object as a
+required assertion.** Their feature map and our `required_assertions` are two
+spellings of one list.
+
+**Wrong for us: the artifact is markdown.** Markdown is not reproducible, not
+hashable, and drifts in silence, which is why pstack needs a second skill,
+`maintain-verification-skill`, to repair it. Our digest already solves that for
+anything the gate points at, and only for things that are files with content
+somebody runs.
+
+## The shape
+
+1. **The artifact is a program, not a runbook.** It takes the repository,
+   launches the real entry point, drives it, and emits the JSON report the
+   manifest cites. `adoption-scenario.sh` is the reference shape, including its
+   own header: a harness is not the actor, and
+   `L3.GATE_HAS_FRESH_EVIDENCE` already refuses a manifest that credits the run
+   to the harness.
+2. **It comes out of an interview, not a template.** No template knows how to
+   start somebody's product. `interview/decisions.yaml` and `sf init --answers`
+   are the mechanism that already exists for turning answers into
+   configuration, and a second mechanism beside it is a second thing to keep
+   true.
+3. **The observable criteria land in policy as `required_assertions`,** not in a
+   prose directory. `L3.GATE_COVERS_THE_PLAN` reads that list. It cannot read a
+   markdown feature map, and a list two checks disagree about is worse than one
+   list.
+4. **The harness sits inside the gate's activation paths.** Then editing the way
+   the product is driven expires the evidence, and re-running is the only fix,
+   which is the property the whole layer turns on.
+
+## This repository is the fixture
+
+`adoption-scenario.sh` was written by hand before any of this existed, and it is
+correct: it walks the README quickstart against a repository nobody tuned the
+tool for, writes one new violation, and checks that the build refuses it. That
+makes it the test.
+
+Run the generator on this repository. It has to produce a harness that emits a
+report carrying the same four `adoption` assertions, and `sf seal adoption`
+against that report has to leave the gate green. If the generator cannot
+reproduce the one verifier we already know is right, it writes runbooks and is
+not a feature.
+
+That swap is also the end-to-end test of `sf` itself. Today adoption is proven
+by a script we maintain next to the tool. After this, it is proven by a harness
+the tool produced, running the tool, on a codebase that never heard of it. The
+tool is then inside its own loop, which is the only version of this that keeps
+working when nobody is watching.
+
+## What is not decided here
+
+**Subcommand or skill.** A subcommand has to embed a language-neutral notion of
+"launch this product", which the tool does not have and cannot acquire by
+parsing. A skill can ask. The precedent points at a skill that interviews and a
+thin command that consumes the answers, exactly as `factory-init` and
+`sf init --answers` split today, but this is a product-surface decision and
+naming it wrongly is expensive: subcommand names are as public as rule ids.
+
+**Whether a gate is required to name a runnable harness.** That is a floor under
+L3, and [a gate bigger than its proofs](a-gate-bigger-than-its-proofs.md)
+already owns L3's floor. Landing half of it here would split one rule across two
+plans, which is the failure that plan is itself about.
+
+**Whether the doctor step earns its separation.** pstack splits readiness from
+driving. Our single worked example folds them together and has not wanted the
+split, and one example is not enough to decide it.
+
+## Non-goals
+
+No browser driver, no sandbox, no seed data. The harness is whatever the
+product's real entry point needs, and a tool that ships an opinion about that
+is a tool for one stack.
+
+L3's five clauses are not touched. This adds the missing producer in front of
+them; it does not soften anything they check.
+
+The generator does not get to write the manifest's `actor`. That field records
+who ran the thing, and a generator that fills it in is a generator that credits
+runs to itself.
+
+## Acceptance criteria
+
+- [ ] The subcommand-or-skill decision above is written into `docs/rules.md` or
+      `docs/method.md` before anything ships
+      (proof: unspecified:a decision about the product surface, which no check
+      can validate, and command names are a public contract)
+- [ ] The generator, run against this repository, produces a harness that emits
+      a report carrying all four `adoption` assertions
+      (proof: deferred:the generator is not written yet)
+- [ ] That generated harness replaces the hand-written
+      `.software-factory/evidence/adoption-scenario.sh`, and its path sits
+      inside the `adoption` gate's activation paths so editing it expires the
+      evidence
+      (proof: deferred:the generator is not written yet)
+- [ ] `sf check --rule L3.GATE_HAS_FRESH_EVIDENCE` is green on the manifest
+      sealed against the generated harness's report, and goes red when
+      `src/init.rs` changes without the harness being re-run
+      (proof: test:.software-factory/evidence/adoption-scenario.sh)
+- [ ] The generator runs against a repository nobody tuned it for whose product
+      has a real startup dependency, and the harness it writes reports failed
+      when that product is broken
+      (proof: deferred:no corpus with a startup dependency is chosen yet)
+- [ ] An adopter enabling L3 reaches a first sealed gate without hand-writing
+      the policy entry, the manifest, the report and the harness
+      (proof: deferred:`sf init` writes `gates: {}` and the interview has no
+      answer that enables L3)
+- [ ] If a check ships with this, `sf verify` proves it fires on its own
+      mutation fixture
+      (proof: deferred:whether any check ships is undecided above)
+
+**Exit condition:** this repository's `adoption` evidence is produced by a
+harness the tool generated rather than one we wrote, the gate is sealed against
+that report and `sf check` is green, and the same generator run against a
+repository nobody tuned it for produces a harness whose report goes red when
+that product is broken.


### PR DESCRIPTION
## The defect

L3 verifies a report of a run against the real thing. Nothing in `sf` produces that run, and nothing checks that a way to produce it exists.

Measured in this repository:

- `sf init` writes `gates: {}` into every policy it scaffolds (`src/init.rs:367`)
- `interview/decisions.yaml` has thirteen decisions and none mentions L3 or a gate, so there is no interview path to a first gate
- `skills/factory-evidence/SKILL.md` step 3 is the entire product surface for producing a run: "Start the actual entry point a customer would use"
- the only worked example anywhere is `.software-factory/evidence/adoption-scenario.sh`, 4.5 KB of shell written by hand, which no rule reads

## Prior art

pstack's `create-verification-skill` interviews the codebase and writes launch, doctor, drive, evidence and cleanup into a skill file, plus one file per feature with its observable success criteria. Two things it gets right for us: the discovery is expensive and belongs in the repository, and a feature with an observable criterion is the same object as a `required_assertion`.

What does not transfer: the artifact is markdown, so it is not reproducible or hashable and drifts in silence, which is why they need a second skill to repair it. Here the artifact is a program that emits the report, sitting inside the gate's activation paths, so the digest we already have expires it.

## The proof

The generator has to reproduce this repository's own `adoption` harness: same four assertions, `sf seal adoption` against its report, gate still green. `adoption-scenario.sh` was written by hand before any of this and is correct, which makes it the oracle. If the generator cannot reproduce the one verifier we know is right, it writes runbooks.

That swap is also how `sf` gets tested end to end: adoption stops being proven by a script we maintain next to the tool, and starts being proven by a harness the tool generated, running the tool, on a codebase that never heard of it.

## Verified

```
sf check --allow-commands
✓ 34 rules, no findings (1 frozen by the ratchet)
```

Includes `L4.PLAN_CRITERION_NAMES_ITS_CHECK`, `L4.PLAN_DECLARES_EXIT_CONDITION`, `L4.DOC_LINKS_RESOLVE` and both L3 rules.

## Note

Slotted at #2 in `plans/next-steps.md`, after the plan that is its precondition, so rows 2 to 6 shift to 3 to 7. The parked row's "Version-conditional activation (#2)" was bumped to #3 to keep pointing at the same row. That reference looked stale before this change and was left as it was otherwise.