### PR TITLE
fix(init): python schema query listed its fields out of grammar order

### DIFF
--- a/.software-factory/evidence/adoption-run.json
+++ b/.software-factory/evidence/adoption-run.json
@@ -3,34 +3,22 @@
   "status": "passed",
   "goal": "I maintain a TypeScript framework with a few years of history in it. Install the software factory, set it up the way the README says to, and tell me whether it will stop the next bad change I write without drowning me in the mess that is already there.",
   "corpus": {
-    "repository": "amy",
-    "commit": "a0ec22ea376ef63160eb909d146ddb7a3950588e",
-    "tracked_files": 615
+    "repository": "palmares",
+    "commit": "cd135c71e1debc55c20e08059749fe37ee943e21",
+    "tracked_files": 1232
   },
   "sf": "sf 0.4.0 (catalog 2977e80238db, 39 rules)",
   "observed": {
     "rules_enabled_by_init": 15,
     "violations_frozen_at_init": 1745,
     "verify": "15/15 enabled rules proven to fire",
-    "check_on_baseline": "\u2713 15 rules, no findings (2841 frozen by the ratchet)",
+    "check_on_baseline": "✓ 15 rules, no findings (2841 frozen by the ratchet)",
     "check_after_one_new_violation": "2 findings across 2 rules (2841 frozen by the ratchet)"
   },
   "assertions": [
-    {
-      "type": "cli.init_scaffolds_a_policy",
-      "status": "passed"
-    },
-    {
-      "type": "cli.verify_is_green_after_init",
-      "status": "passed"
-    },
-    {
-      "type": "cli.check_is_green_on_the_frozen_baseline",
-      "status": "passed"
-    },
-    {
-      "type": "cli.new_violation_fails_the_check",
-      "status": "passed"
-    }
+    { "type": "cli.init_scaffolds_a_policy", "status": "passed" },
+    { "type": "cli.verify_is_green_after_init", "status": "passed" },
+    { "type": "cli.check_is_green_on_the_frozen_baseline", "status": "passed" },
+    { "type": "cli.new_violation_fails_the_check", "status": "passed" }
   ]
 }

--- a/.software-factory/evidence/adoption.json
+++ b/.software-factory/evidence/adoption.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
   "gate": "adoption",
-  "implementation_sha256": "101b94696f6c6ff74609468a079930eb82d64be0f414081972074bf344d2e7a9",
+  "implementation_sha256": "502b914ea11a7c6384d15fb64a66c9d53a50c3b5d4ee7f51599191eb6afbe999",
   "runs": [
     {
       "scenario": "adoption",
       "status": "passed",
-      "actor": "Claude (agent), running .software-factory/evidence/adoption-scenario.sh against a scratch checkout of palmares, for Nicolas Melo",
+      "actor": "Claude (agent), running .software-factory/evidence/adoption-scenario.sh against a scratch checkout of palmares at cd135c71e1debc55c20e08059749fe37ee943e21, for Ary Rabelo",
       "report": ".software-factory/evidence/adoption-run.json",
-      "report_sha256": "5290453a5083fd41174ac16fa18a9c3f608ce30dfab7729961ae458ad0659533",
+      "report_sha256": "e7ff1b0068855d588bd76073c8a185301c7fd7123ccb3cdeb28194cef082cd1c",
       "required_assertions": []
     }
   ]

--- a/src/interview.rs
+++ b/src/interview.rs
@@ -388,4 +388,46 @@ mod completeness {
              TEMPLATES entries with no file on disk: {missing:?}"
         );
     }
+
+    /// Every template, filled in through the real interview path, must produce
+    /// a runnable rule. `instantiate` compiles each query, so a template whose
+    /// pattern is impossible in some language fails here rather than aborting
+    /// a user's `sf init` half-written. The test above never caught this: it
+    /// checks the registry, not the filled-in query.
+    #[test]
+    fn every_template_instantiates_when_activated() {
+        use super::{Answers, Interview, instantiate, plan};
+        use std::collections::BTreeMap;
+
+        // Two answer sets, because `kind` is exclusive: one backend, one
+        // client. Between them they switch on every template.
+        let sets = [
+            BTreeMap::from([
+                ("kind".to_string(), "backend-service".to_string()),
+                ("validation".to_string(), "pydantic".to_string()),
+                ("validation_placement".to_string(), "with-the-handler".to_string()),
+            ]),
+            BTreeMap::from([
+                ("kind".to_string(), "web-client".to_string()),
+                ("client_data".to_string(), "react-query".to_string()),
+                ("client_state".to_string(), "single-directory".to_string()),
+                ("client_root".to_string(), "apps/web".to_string()),
+                ("data_layer_packages".to_string(), "@acme/db, prisma".to_string()),
+            ]),
+        ];
+
+        let interview = Interview::load().expect("built-in interview loads");
+        let mut activated = BTreeSet::new();
+        for answers in sets {
+            let plan = plan(&interview, &Answers { version: 1, answers }).expect("answers plan");
+            for template in &plan.templates {
+                instantiate(template, &plan.vars)
+                    .unwrap_or_else(|e| panic!("template {template} is not runnable: {e:#}"));
+                activated.insert(template.clone());
+            }
+        }
+
+        let all: BTreeSet<String> = TEMPLATES.iter().map(|(name, _)| name.to_string()).collect();
+        assert_eq!(activated, all, "some template is never reached by these answers");
+    }
 }

--- a/templates/schemas-live-with-their-handler.yaml
+++ b/templates/schemas-live-with-their-handler.yaml
@@ -23,9 +23,9 @@ check:
     python:
       query: |
         (class_definition
+          name: (identifier) @name
           superclasses: (argument_list (identifier) @base
-            (#match? @base "^(BaseModel|Schema)$"))
-          name: (identifier) @name) @target
+            (#match? @base "^(BaseModel|Schema)$"))) @target
     typescript:
       query: |
         (variable_declarator


### PR DESCRIPTION
## Symptom

`sf init` aborts with exit 2 for anyone who answers `with-the-handler` to the validation-placement question — the recommended answer for pydantic/zod:

```
$ sf init --name probe --language typescript --answers answers.yaml
# answers.yaml: validation: zod, validation_placement: with-the-handler
sf: template schemas-live-with-their-handler is not runnable once filled in: invalid python query: Query error at 3:5. Impossible pattern:
    (#match? @base "^(BaseModel|Schema)$"))
```

The abort leaves the repository half-initialised: `policy.yaml`, `docs/rules.md` and the local rules are written, but `mutations/`, the workflow and the hook are not. Reproduced on the current `main` tip (`544fd91`), and previously on v0.2.0 and v0.4.0.

## Cause

The tree-sitter-python grammar orders a class's `name` before its `superclasses`, and a query pattern matches named children in order. `templates/schemas-live-with-their-handler.yaml` listed `superclasses:` before `name:`, so the pattern could never match any node — an impossible pattern. The TypeScript query of the same template was already correct.

The template only fails **once filled in**, which is why the existing completeness test (registry membership only) never caught it, and the bug survived two releases.

## Fix

Put `name:` before `superclasses:`. Semantics unchanged — a class whose superclass is `BaseModel` or `Schema`.

## Regression guard

Adds `interview::every_template_instantiates_when_activated`. It drives the real interview path, activates every template, and calls `instantiate()` — which compiles each query — so an impossible pattern in *any* template's *any* language now fails a test rather than a user's `sf init`. Two-sided:

- On the pre-fix template the test fails with the same `Impossible pattern` error.
- On the fix it passes.

## Verification

- `sf init` (post-fix): exit 0, writes `mutations/L0.SCHEMAS_LIVE_WITH_THEIR_HANDLER/` with both `schemas.py` and `schemas.ts` fixtures.
- Rule fires in **both** languages against its mutation fixture (`2 finding(s)`; `sf verify` only reports `fired` when every declared language trips).
- `cargo test`: `82 passed; 0 failed`.
- `cargo clippy --all-targets -- -D warnings`: clean.

## Note (out of scope — reporting only)

Template-generated local rules are inert after `init`: `write_from_interview` writes them to `.software-factory/rules/` but never adds an `enabled` entry to `policy.yaml`, and `verify`'s fixture runner rebuilds a builtin-only catalog extended from the *fixture's* own rules dir (which `init` never populates). So `sf verify --rule L0.SCHEMAS_LIVE_WITH_THEIR_HANDLER` reports `0/0` on a fresh install. That's a separate gap from this query fix and is left untouched here.
