### PR TITLE
fix(init): enable and prove template rules on a fresh install

### DIFF
--- a/.software-factory/evidence/adoption.json
+++ b/.software-factory/evidence/adoption.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "gate": "adoption",
-  "implementation_sha256": "126a0a2965d9649a56831182d40195830929a47c347bb53d38624933d06b565d",
+  "implementation_sha256": "51697c5d6c817b3443849857010b60dbbb279526134fdb6c9c0890940bde3fd0",
   "runs": [
     {
       "scenario": "adoption",

--- a/src/init.rs
+++ b/src/init.rs
@@ -44,11 +44,12 @@ pub fn run(root: &Path, catalog: &Catalog, opts: &InitOptions) -> Result<Vec<Str
         bail!("no rules match the requested layers");
     }
 
+    let template_rules = interview_rules(opts)?;
     let mut written = Vec::new();
-    write(root, POLICY_PATH, &policy_document(opts, &selected, root), &mut written)?;
-    write(root, opts.rules_document.as_deref().unwrap_or("docs/rules.md"), &rules_document(opts, &selected), &mut written)?;
-    if let (Some(plan), Some(answers)) = (&opts.plan, &opts.answers) {
-        write_from_interview(root, plan, answers, &mut written)?;
+    write(root, POLICY_PATH, &policy_document(opts, &selected, root, &template_rules), &mut written)?;
+    write(root, opts.rules_document.as_deref().unwrap_or("docs/rules.md"), &rules_document(opts, &selected, &template_rules), &mut written)?;
+    if let Some(answers) = &opts.answers {
+        write_from_interview(root, answers, &template_rules, &mut written)?;
     }
     write_cadence_files(root, &selected, &mut written)?;
     write_if_absent(
@@ -63,17 +64,30 @@ pub fn run(root: &Path, catalog: &Catalog, opts: &InitOptions) -> Result<Vec<Str
     Ok(written)
 }
 
+/// Instantiate the templates the interview asked for, once. The policy has to
+/// enable each one and each fixture has to carry it, so both are computed from
+/// the same list — and a template that fails to fill in aborts the whole init
+/// before anything is written.
+fn interview_rules(
+    opts: &InitOptions,
+) -> Result<Vec<(String, crate::interview::Instantiated)>> {
+    let Some(plan) = &opts.plan else { return Ok(Vec::new()) };
+    plan.templates
+        .iter()
+        .map(|name| Ok((name.clone(), crate::interview::instantiate(name, &plan.vars)?)))
+        .collect()
+}
+
 /// Rules the interview asked for that are not in the catalog: templates with
 /// this repository's own names filled in, each with the fixture that proves it
 /// fires, plus the record of who decided what.
 fn write_from_interview(
     root: &Path,
-    plan: &crate::interview::Plan,
     answers: &crate::interview::Answers,
+    template_rules: &[(String, crate::interview::Instantiated)],
     written: &mut Vec<String>,
 ) -> Result<()> {
-    for name in &plan.templates {
-        let built = crate::interview::instantiate(name, &plan.vars)?;
+    for (name, built) in template_rules {
         write(root, &format!("{RULES_DIR}/{name}.yaml"), &built.body, written)?;
         let base = format!("{FIXTURES_DIR}/{}", built.rule.id);
         write(
@@ -82,6 +96,13 @@ fn write_from_interview(
             &fixtures::minimal_policy(&built.rule.id),
             written,
         )?;
+        // The fixture runs under a builtin-only catalog extended by its own
+        // rules dir (verify::run_fixture, `let _ = catalog`). A template rule
+        // is not builtin, so without its yaml here the fixture has nothing to
+        // trip and the mutation proves nothing — the rule would read as
+        // verified while being untested. Copy it beside the policy that
+        // enables it.
+        write(root, &format!("{base}/{RULES_DIR}/{name}.yaml"), &built.body, written)?;
         for (path, body) in &built.fixture {
             write(root, &format!("{base}/{path}"), body, written)?;
         }
@@ -366,7 +387,12 @@ fn interview_options(opts: &InitOptions, rule_id: &str) -> Option<String> {
     Some(format!("    options:\n{indented}"))
 }
 
-fn policy_document(opts: &InitOptions, selected: &[&crate::catalog::Rule], root: &Path) -> String {
+fn policy_document(
+    opts: &InitOptions,
+    selected: &[&crate::catalog::Rule],
+    root: &Path,
+    template_rules: &[(String, crate::interview::Instantiated)],
+) -> String {
     let mut out = String::new();
     out.push_str(
         "# Which rules this repository enforces, and how its paths map onto the\n\
@@ -410,6 +436,28 @@ fn policy_document(opts: &InitOptions, selected: &[&crate::catalog::Rule], root:
                 "    options:\n      # Nothing is locked until you say what is generated. An enabled\n      \
                  # lock with an empty scope is inert, and L5.NO_INERT_RULE will say so.\n      scope: []\n",
             );
+        }
+    }
+    out.push_str(&template_rule_entries(opts, template_rules));
+    out
+}
+
+/// The policy lines that switch on the template rules an interview
+/// instantiated. They are not in the builtin catalog, so the main loop in
+/// `policy_document` never sees them; enabling them here is what makes the
+/// interview's promise real instead of a rule that only reads well in
+/// docs/rules.md. Each rule's config rides in the template's own `defaults`.
+fn template_rule_entries(
+    opts: &InitOptions,
+    template_rules: &[(String, crate::interview::Instantiated)],
+) -> String {
+    let mut out = String::new();
+    for (_, built) in template_rules {
+        let rule = &built.rule;
+        out.push_str(&format!("  # {} — {}\n", rule.layer.as_str(), rule.title));
+        out.push_str(&format!("  {}:\n    enabled: true\n", rule.id));
+        if let Some(block) = interview_options(opts, &rule.id) {
+            out.push_str(&block);
         }
     }
     out
@@ -460,8 +508,15 @@ fn rules_preamble(name: &str) -> String {
     )
 }
 
-fn rules_document(opts: &InitOptions, selected: &[&crate::catalog::Rule]) -> String {
-    format!("{}\n{}", rules_preamble(&opts.name), rule_sections(selected))
+fn rules_document(
+    opts: &InitOptions,
+    selected: &[&crate::catalog::Rule],
+    template_rules: &[(String, crate::interview::Instantiated)],
+) -> String {
+    let mut all: Vec<&crate::catalog::Rule> = selected.to_vec();
+    all.extend(template_rules.iter().map(|(_, built)| &built.rule));
+    all.sort_by(|a, b| a.id.cmp(&b.id));
+    format!("{}\n{}", rules_preamble(&opts.name), rule_sections(&all))
 }
 
 fn rule_sections(selected: &[&crate::catalog::Rule]) -> String {
@@ -807,6 +862,71 @@ mod conformance {
         assert!(
             policy.any_instance_enabled("L4.PLAN_PROOF_BUDGET"),
             "an existing scoped plan makes the budget meaningful"
+        );
+    }
+
+    #[test]
+    fn a_template_rule_is_enabled_and_verifiable_after_init() {
+        let scratch = Scratch::new("template-rule");
+        let root = scratch.0.as_path();
+        let catalog = Catalog::builtin().expect("builtin catalog");
+
+        // Answers that activate a template: a web client fetching through a
+        // query cache instantiates `no-fetch-inside-an-effect`.
+        let answers = crate::interview::Answers {
+            version: 1,
+            answers: [
+                ("kind".to_string(), "web-client".to_string()),
+                ("client_data".to_string(), "react-query".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+        };
+        let interview = crate::interview::Interview::load().expect("interview loads");
+        let plan = crate::interview::plan(&interview, &answers).expect("plan");
+        run(
+            root,
+            &catalog,
+            &InitOptions {
+                name: "probe".to_string(),
+                languages: vec!["typescript".to_string()],
+                layers: vec!["L1".to_string()],
+                force: false,
+                plan: Some(plan),
+                answers: Some(answers),
+                rules_document: None,
+            },
+        )
+        .expect("sf init succeeds");
+
+        const RULE: &str = "L1.NO_FETCH_INSIDE_AN_EFFECT";
+        let policy = Policy::load(root).expect("generated policy loads");
+
+        // Front 1: the generated policy switches the template rule on. Before
+        // the fix the rule's yaml and fixture were written but no policy entry
+        // was, so `sf check` skipped it — enabled nowhere, enforced never.
+        assert!(
+            policy.any_instance_enabled(RULE),
+            "template rule was written but never enabled in the generated policy"
+        );
+
+        // Fronts 1+2 together: `sf verify` proves the rule fires against the
+        // generated mutation fixture. This is what fails without the rules-dir
+        // copy — the fixture runner rebuilds a builtin-only catalog extended
+        // from the fixture's own rules dir, and a template rule is not builtin,
+        // so the fixture has nothing to trip.
+        let mut local = Catalog::builtin().expect("builtin catalog");
+        local.extend_from_dir(&root.join(RULES_DIR)).expect("local rules load");
+        let outcomes =
+            crate::verify::run(root, &policy, &local, Some(RULE), false).expect("verify runs");
+        let outcome = outcomes
+            .iter()
+            .find(|o| o.rule == RULE)
+            .expect("verify considered the template rule");
+        assert!(
+            outcome.fired,
+            "the generated fixture did not prove the rule fires: {}",
+            outcome.detail
         );
     }
 


### PR DESCRIPTION
## Symptom

The interview sells guardrails it does not install. A team answers `validation_placement: with-the-handler` (or picks a query cache, a store directory, a data layer), sees the rule in `docs/rules.md`, and believes it is protected. On a fresh install the rule is inert: `sf check` never enforces it and `sf verify` cannot prove it fires.

Reproduced on `no-fetch-inside-an-effect` (a web client with a query cache), before this change:

```
$ sf init --name p --language typescript --answers answers.yaml   # kind: web-client, client_data: react-query
$ grep -c NO_FETCH_INSIDE_AN_EFFECT .software-factory/policy.yaml
0
$ # plant the exact violation the rule exists to catch:
$ sf check | grep -i NO_FETCH || echo "RULE NEVER FIRES (inert)"
RULE NEVER FIRES (inert)
$ sf verify --rule L1.NO_FETCH_INSIDE_AN_EFFECT
0/0 enabled rules proven to fire
```

After:

```
$ grep -c NO_FETCH_INSIDE_AN_EFFECT .software-factory/policy.yaml
1
$ sf check
✗ high L1.NO_FETCH_INSIDE_AN_EFFECT — Data fetching does not happen inside an effect
    src/components/usage.tsx:3 — `fetch("/api/x")` appears inside the guarded region starting at line 2
$ sf verify --rule L1.NO_FETCH_INSIDE_AN_EFFECT
1/1 enabled rules proven to fire
```

Same before/after for the flagship `schemas-live-with-their-handler` (python + typescript), proven in **both** declared languages (`sf verify` reports `fired` only when every declared language trips):

```
$ grep -c SCHEMAS_LIVE_WITH_THEIR_HANDLER .software-factory/policy.yaml       # 0 -> 1
$ sf check      # now accuses src/api/schemas.py
! medium L0.SCHEMAS_LIVE_WITH_THEIR_HANDLER — Request and response schemas are defined beside the handler that uses them
    src/api/schemas.py:4 — `CreateThing` appears where this rule forbids it
$ sf verify --rule L0.SCHEMAS_LIVE_WITH_THEIR_HANDLER
1/1 enabled rules proven to fire
```

(The schemas probe requires the python query fix from #43, which is not on this branch — see the note at the end. It was applied locally, uncommitted, only to produce this two-language evidence; `no-fetch` needs nothing beyond `main`.)

## Cause — three coupled fronts

1. **Never enabled.** `write_from_interview` writes the filled template to `.software-factory/rules/<name>.yaml` and its mutation fixture, but `policy_document` only ever emits `enabled: true` for builtin catalog rules (`selected`). The template rule gets no policy entry, and since `verify`/`check` filter by `policy.any_instance_enabled(id)`, it is skipped.
2. **Fixture cannot resolve the rule.** `verify::run_fixture` rebuilds a builtin-only catalog and extends it from the *fixture's own* rules dir (`let _ = catalog;` — the fixture is deliberately self-contained). `init` never copied the rule's yaml into that dir, so even with the rule enabled the fixture has nothing to trip: `verify` reports "the mutation did not trip the rule".
3. **Docs would drift.** A fresh `backend-service`/`web-client` install enables `L4.EVERY_RULE_HAS_A_WHY`, which requires every enabled rule to be cited in the docs. Enabling a template rule without adding it to the generated `docs/rules.md` would hand the adopter a red first `sf check`.

## Fix (`src/init.rs`)

- Templates are instantiated once, up front, in `run()` (`interview_rules`), so the policy can enable them and the fixtures can carry them from one list — and a template that fails to fill in aborts init before writing a half install.
- `policy_document` emits `enabled: true` for every template rule (via `template_rule_entries`, kept separate so `policy_document` stays under the complexity ceiling). Config rides in each template's own `defaults`, so no options block is needed.
- `rules_document` merges the template rules with the builtin ones, sorted by id, so `docs/rules.md` documents what is enforced (matching `sf docs` output) and `L4.EVERY_RULE_HAS_A_WHY` stays green.
- `write_from_interview` copies each rule's yaml into its fixture's `.software-factory/rules/` dir, so `run_fixture` has the rule to trip.

Applies to all four templates (`schemas-live-with-their-handler`, `no-fetch-inside-an-effect`, `global-state-lives-in-one-place`, `client-never-imports-the-data-layer`).

## Test (two-sided)

`init::conformance::a_template_rule_is_enabled_and_verifiable_after_init` drives the real init path from interview answers and asserts (a) the template rule is enabled in the generated policy and (b) `verify::run` proves it fires against the generated fixture. The bug survived because nothing exercised the generated policy+fixture together.

Reverting either front fails it:

```
# front 1 disabled (no policy enable):
thread '...a_template_rule_is_enabled_and_verifiable_after_init' panicked:
  template rule was written but never enabled in the generated policy
test result: FAILED. 0 passed; 1 failed

# front 2 disabled (no rules-dir copy in the fixture):
thread '...a_template_rule_is_enabled_and_verifiable_after_init' panicked at src/init.rs:911:
  the generated fixture did not prove the rule fires: ...
test result: FAILED. 0 passed; 1 failed

# both fronts present:
test result: ok. 1 passed
```

## Verification

- `cargo test`: `test result: ok. 82 passed; 0 failed; 0 ignored`
- `cargo clippy --all-targets -- -D warnings`: clean
- `sf verify`: `34/34 enabled rules proven to fire` (exit 0)
- `sf check --allow-commands`: `✓ 35 rules, no findings (3 frozen by the ratchet)` (exit 0)

The `adoption` gate activates on `src/init.rs`, so touching it expired the gate's implementation digest. The adoption scenario runs `sf init --language typescript` with no `--answers` — the path this change leaves untouched — so adoption behaviour is unaffected; re-running `adoption-scenario.sh` against a real TypeScript corpus with the new binary passes all four assertions (`15/15` verify, baseline green with 47 frozen, first new violation refused). Refreshed with `sf seal adoption`; the recorded run's provenance is left intact.

## Note (out of scope — reporting only)

- **#43 (python schema query) is a prerequisite for the schemas template.** On `main` the `schemas-live-with-their-handler` python query lists `superclasses:` before `name:` (an impossible tree-sitter pattern), so `instantiate()` fails. Because this change now instantiates templates up front, that pre-existing crash surfaces as a clean init abort instead of a half-written install. #43 fixes the query; this branch does not touch it. The two compose: once #43 lands, the schemas template is enabled and proven by the same mechanism (evidence above, produced with #43 applied locally).
