### PR TITLE
ci: automate release PRs with release-plz

### DIFF
--- a/.allowed-root-files
+++ b/.allowed-root-files
@@ -3,6 +3,7 @@
 .allowed-root-files
 .gitignore
 AGENTS.md
+CHANGELOG.md
 Cargo.lock
 Cargo.toml
 LICENSE
@@ -14,6 +15,8 @@ catalog
 docs
 interview
 plans
+release-plz.toml
+scripts
 skills
 src
 templates

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,83 @@
+# A release is proposed, reviewed, and merged like every other change. On each
+# push to main, release-plz first releases only a merged release PR, then opens
+# or refreshes the next one from the conventional commits still unreleased.
+name: release-plz
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Release merged release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    outputs:
+      released: ${{ steps.release-plz.outputs.releases_created }}
+      tag: ${{ fromJSON(steps.release-plz.outputs.releases)[0].tag }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: release-plz
+        uses: release-plz/action@503fe65046e8810d4844f6b3aa12ab599a3549d7 # v0.5.134
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  attach-binaries:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+
+  release-pr:
+    name: Prepare next release PR
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+          # The derived release artifacts are committed to the release PR after
+          # release-plz creates its verified version/changelog commit.
+          persist-credentials: true
+      - id: release-plz
+        uses: release-plz/action@503fe65046e8810d4844f6b3aa12ab599a3549d7 # v0.5.134
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update the release PR's derived artifacts
+        if: steps.release-plz.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.release-plz.outputs.pr }}
+        run: |
+          set -eu
+          pr_number=$(printf '%s' "$PR" | jq -er '.number')
+          gh pr checkout "$pr_number"
+          ./scripts/prepare-release-pr.sh
+          if git diff --quiet; then
+            echo "release-plz left every derived artifact current"
+            exit 0
+          fi
+          git add README.md Cargo.lock .software-factory/catalog.lock.json .software-factory/ratchet.yaml docs
+          git commit -m "chore: refresh release derivatives"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,21 @@
 name: release
 
 on:
-  push:
-    tags: ["v*"]
+  # release-plz calls this workflow after it creates the tag and GitHub release.
+  # Keeping the binary build in a reusable workflow means the release operation
+  # and its assets share one token/run rather than relying on a tag event that
+  # GitHub deliberately does not trigger for the default Actions token.
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to verify and populate
+        required: true
+        type: string
 
 # Nothing here writes to the repository. The release job needs contents: write
 # to create the release itself, and it is the only job that gets it.
@@ -36,7 +49,7 @@ jobs:
       # people.
       - name: The tag matches the built version
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.tag }}
         run: |
           set -eu
           built="v$(./target/release/sf --version | awk '{print $2}')"
@@ -117,7 +130,7 @@ jobs:
       # prose naming a command.
       - name: Compose the notes
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.tag }}
         run: |
           set -eu
           # Single-quoted on purpose: the backticks are literal markdown, and
@@ -137,7 +150,7 @@ jobs:
       - name: Publish
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ inputs.tag }}
         # `gh` is on the runner already. A third-party release action would be
         # one more SHA to pin and one more thing holding a write token.
         #

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -1,11 +1,14 @@
 {
   "schema_version": 1,
   "files": {
-    ".allowed-root-files": "20889fd9828de3c601e63bae4c430692846319df116688c1322bd230bdfc1995",
+    ".allowed-root-files": "102b1708337d1303a590f8f0201ea147c4c10bc3b41b8e64650b83de9d34aed5",
     ".githooks/pre-commit": "47642e2f720762fecb49bdaecbe28afec61f6ab1611c14c36cf70e240f18b072",
-    ".github/workflows/release.yml": "b8beb43a7b8606aa17a79e069426798f4dd16e169493805a2205abc3213bc002",
+    ".github/workflows/release-plz.yml": "49e4c37eb2dbb3b95b2fdf68b02640d7ee47565a6509cdb16b03cb33d85805f8",
+    ".github/workflows/release.yml": "cfbf7dfa023db1c52ef6c9fc5111f7df5e151bdb39a0dc992adaf60011579ec3",
     ".github/workflows/software-factory.yml": "0350f6ff218f228765453461949d2c9b7ce5158c0705a7968c332a7b629f7eab",
-    ".software-factory/policy.yaml": "4699ea46665890d439cfba4dce46a92e776130b7c7211ff53b37af9c90d5cbf0",
-    ".software-factory/ratchet.yaml": "42611c9974434ff314625fb33bc49b24517ca5bdf3fb629538c271b2f7a03db5"
+    ".software-factory/policy.yaml": "a1bddb926bd1befae06e65f224ad264979b51a01856fce4e71d593353624d09c",
+    ".software-factory/ratchet.yaml": "42611c9974434ff314625fb33bc49b24517ca5bdf3fb629538c271b2f7a03db5",
+    "release-plz.toml": "b307798df7eee1e3a0339c14283aed599c92460e1b2d7d44ed2492fbdc81eced",
+    "scripts/prepare-release-pr.sh": "ddd1904a42f77c5331f9e0abfc39fa0fa092db8ea03bf60a1d1ad65dd8cf0a92"
   }
 }

--- a/.software-factory/policy.yaml
+++ b/.software-factory/policy.yaml
@@ -110,6 +110,9 @@ rules:
         - ".allowed-root-files"
         - ".github/workflows/software-factory.yml"
         - ".github/workflows/release.yml"
+        - ".github/workflows/release-plz.yml"
+        - "release-plz.toml"
+        - "scripts/prepare-release-pr.sh"
         - ".githooks/pre-commit"
   # L2 — Generated artifacts are hash-locked and not hand-edited
   L2.GENERATED_FILES_ARE_LOCKED:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,15 @@
+[workspace]
+# This project distributes GitHub releases and platform binaries, not a crate on
+# crates.io. Tags, rather than the cargo registry, are the release source of
+# truth; the reusable release workflow attaches the binaries to that release.
+git_only = true
+git_release_enable = true
+publish = false
+release_always = false
+# `sf` is a binary, so cargo-semver-checks has no public library API to inspect.
+semver_check = false
+pr_labels = ["release"]
+
+[[package]]
+name = "sf"
+changelog_path = "CHANGELOG.md"

--- a/scripts/prepare-release-pr.sh
+++ b/scripts/prepare-release-pr.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Complete the artifacts derived from Cargo.toml after release-plz creates or
+# refreshes its release PR. release-plz owns the version and changelog; this
+# script owns this repository's declared derivatives of that version.
+set -eu
+
+version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml)
+if [ -z "$version" ]; then
+  echo "could not read the package version from Cargo.toml" >&2
+  exit 1
+fi
+
+python3 - "$version" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path("README.md")
+content = path.read_text()
+updated, replacements = re.subn(
+    r"(--tag v)[0-9]+\.[0-9]+\.[0-9]+",
+    rf"\g<1>{sys.argv[1]}",
+    content,
+    count=1,
+)
+if replacements != 1:
+    raise SystemExit("README.md must contain exactly one cargo install tag")
+path.write_text(updated)
+PY
+
+cargo build --release --locked
+./target/release/sf fixtures
+./target/release/sf docs
+./target/release/sf ratchet
+./target/release/sf lock
+
+cargo test --locked
+./target/release/sf verify --allow-commands
+./target/release/sf check --allow-commands


### PR DESCRIPTION
## Summary

- adds a pinned `release-plz` workflow that maintains one Conventional-Commits release PR from `main`
- releases only after that `release-plz-*` PR is merged; the release remains GitHub binaries/tags only, not crates.io publication
- invokes the existing binary build as a reusable workflow, so the release tag, GitHub release, and uploaded platform binaries happen in the same workflow run
- refreshes the repository's version-derived README, locks, and generated artifacts in each release PR

## Verification

- `cargo test --locked` — 118 passed
- `cargo clippy --all-targets -- -D warnings -D dead_code`
- `./target/release/sf verify --allow-commands` — 35/35 enabled rules proven to fire
- `./target/release/sf check --allow-commands` — 36 rules, no findings (3 frozen)
- `actionlint -color -shellcheck=`
- `shellcheck scripts/prepare-release-pr.sh`
- simulated a `0.4.1` release-PR version bump in an isolated worktree; the preparation script updated the README and all derived artifacts, then completed its tests, `sf verify`, and `sf check`

## Scope

No release was created and no repository secret was added. The workflow uses the repository's default `GITHUB_TOKEN`; release-plz documentation notes that checks are not independently re-triggered on its bot-authored PR, so the preparation job itself executes the project gates and the release workflow re-runs them against the merged release commit.
