### PR TITLE
ci(release-plz): open the release PR with a GitHub App token

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -25,6 +25,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      # This job keeps the Actions token on purpose. It opens no pull request,
+      # so the refusal below does not reach it, and nothing waits on the tag it
+      # pushes: `attach-binaries` is a workflow call in this same run, which is
+      # what the comment in `release.yml` is about. A credential nobody needs
+      # is a credential worth not issuing.
       - id: release-plz
         uses: release-plz/action@503fe65046e8810d4844f6b3aa12ab599a3549d7 # v0.5.134
         with:
@@ -45,34 +50,77 @@ jobs:
     name: Prepare next release PR
     needs: release
     runs-on: ubuntu-latest
+    # Nothing in this job holds the Actions token any more, so it asks for no
+    # write of its own. The app token below is the only credential here, and it
+    # is scoped by the app's installation rather than by this block.
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      # Why an app instead of `secrets.GITHUB_TOKEN`. Two reasons, and the
+      # second is the one that matters here.
+      #
+      # First, GitHub refuses the call outright: `release-plz release-pr` got
+      # `403 GitHub Actions is not permitted to create or approve pull
+      # requests`. The switch that allows it is repository-wide, so buying one
+      # workflow a release PR would let every workflow open pull requests.
+      #
+      # Second, and worse: a pull request opened with the Actions token
+      # triggers no workflow. The release PR would arrive with no `factory` run
+      # against it, and it is the pull request that edits `Cargo.lock`,
+      # `.software-factory/catalog.lock.json` and the ratchet, each of them
+      # named by `L2.FACTORY_CONFIG_IS_LOCKED`. A release merging without the
+      # gate having run is the hole this repository exists to close.
+      #
+      # An installation token is a different actor, so both problems go away
+      # and the release PR is reviewed like every other change.
+      - id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+          # Narrowed on purpose. Without these the token carries every
+          # permission the installation was granted, which is the same
+          # over-issue as a classic PAT wearing a different name, and zizmor
+          # reports it. These two are what opening the release PR and pushing
+          # its derived artifacts actually need.
+          permission-contents: write
+          permission-pull-requests: write
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           # The derived release artifacts are committed to the release PR after
-          # release-plz creates its verified version/changelog commit.
+          # release-plz creates its verified version/changelog commit, so the
+          # credential has to survive into .git/config. It is the app's and not
+          # the Actions token's for the same reason as above: a push carrying
+          # the Actions token re-runs nothing.
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
       - id: release-plz
         uses: release-plz/action@503fe65046e8810d4844f6b3aa12ab599a3549d7 # v0.5.134
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Update the release PR's derived artifacts
         if: steps.release-plz.outputs.prs_created == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ steps.release-plz.outputs.pr }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -eu
           pr_number=$(printf '%s' "$PR" | jq -er '.number')
           gh pr checkout "$pr_number"
+          # `actions/checkout` sets no committer, and `git commit` refuses to
+          # guess one. The app's bot account is the honest author: it is what
+          # pushed. The numeric id is what links the commit to that account
+          # rather than leaving it unattributed.
+          bot_id=$(gh api "/users/$APP_SLUG%5Bbot%5D" --jq .id)
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${bot_id}+${APP_SLUG}[bot]@users.noreply.github.com"
           ./scripts/prepare-release-pr.sh
           if git diff --quiet; then
             echo "release-plz left every derived artifact current"

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -3,7 +3,7 @@
   "files": {
     ".allowed-root-files": "102b1708337d1303a590f8f0201ea147c4c10bc3b41b8e64650b83de9d34aed5",
     ".githooks/pre-commit": "47642e2f720762fecb49bdaecbe28afec61f6ab1611c14c36cf70e240f18b072",
-    ".github/workflows/release-plz.yml": "49e4c37eb2dbb3b95b2fdf68b02640d7ee47565a6509cdb16b03cb33d85805f8",
+    ".github/workflows/release-plz.yml": "d9eec995a3efe21f85a036582128149d9ad3635543c0145aae31462274faa182",
     ".github/workflows/release.yml": "cfbf7dfa023db1c52ef6c9fc5111f7df5e151bdb39a0dc992adaf60011579ec3",
     ".github/workflows/software-factory.yml": "0350f6ff218f228765453461949d2c9b7ce5158c0705a7968c332a7b629f7eab",
     ".software-factory/policy.yaml": "a1bddb926bd1befae06e65f224ad264979b51a01856fce4e71d593353624d09c",


### PR DESCRIPTION
Fecha o vermelho da main. [Run 34304369684](https://github.com/nicolasmelo1/software-factory/actions/runs/34304369684/job/102317910856) falhou em `release-plz release-pr` com:

```
403 GitHub Actions is not permitted to create or approve pull requests
POST /repos/nicolasmelo1/software-factory/pulls
```

## Por que app e não o flag do repo

O flag existe (`can_approve_pull_request_reviews: false`) e ligar ele resolveria o 403 em segundos. Duas razões para não ligar:

1. Ele é do repo inteiro. Comprar um release PR para um workflow custa deixar todo workflow abrir PR.
2. Pior: [PR aberto com o `GITHUB_TOKEN` não dispara workflow nenhum](https://release-plz.dev/docs/github/token). `software-factory.yml` roda `on: pull_request`, então o release PR chegaria sem nenhum run do `factory`, e ele é justamente o PR que edita `Cargo.lock`, `.software-factory/catalog.lock.json` e o ratchet, todos nomeados por `L2.FACTORY_CONFIG_IS_LOCKED`. O mesmo vale para o commit que o step de artefatos derivados empurra.

Um token de instalação é outro ator, então os dois problemas somem e o release PR é revisado como qualquer outra mudança.

**Nenhum setting do repo foi alterado.** `default_workflow_permissions` segue `read` e Actions continua sem poder criar PR.

## Duas coisas que sairam de rodar actionlint e zizmor localmente, e não de esperar a CI

- zizmor reporta `github-app` como **high** para token que herda a instalação inteira. O token está estreitado para `permission-contents: write` e `permission-pull-requests: write`. O job `hazards` teria falhado nisso.
- O step `Update the release PR's derived artifacts` nunca teria conseguido commitar: `actions/checkout` não define committer e `git commit` se recusa a adivinhar. Agora commita como a conta bot do app, com o id numérico que liga o commit a ela. O shellcheck também lia `"$APP_SLUG[bot]"` como expansão de array (SC1087), então as expansões estão com chaves.

O `permissions` do job caiu de `contents: write` + `pull-requests: write` para `contents: read`, porque nada nele segura mais o token do Actions. O job `release` mantém o token do Actions e diz por quê: não abre PR, e `attach-binaries` é workflow call no mesmo run, não algo esperando o evento de tag.

## O que falta do seu lado, antes de mergear

1. **Criar o app**: Settings → Developer settings → GitHub Apps → New GitHub App. Nome à sua escolha, homepage pode ser a URL do repo, desmarque Webhook → Active.
2. **Permissões** (Repository permissions): `Contents` read/write e `Pull requests` read/write. Nada além.
3. **Instalar** no `nicolasmelo1/software-factory` (Install App → Only select repositories).
4. **Gerar a private key** na página do app (Generate a private key), baixa um `.pem`.
5. **Guardar os dois secrets:**

```sh
gh secret set RELEASE_PLZ_APP_ID --body "<o App ID da página do app>"
gh secret set RELEASE_PLZ_APP_PRIVATE_KEY < ~/Downloads/<seu-app>.private-key.pem
```

Enquanto os secrets não existirem, a main segue vermelha, só que falhando no step `app-token` em vez do 403. Depois de mergear com os secrets no lugar, o próximo push na main abre o release PR e ele vem com `factory` e `hazards` rodando.

## Verificação local

- `actionlint .github/workflows/release-plz.yml`: limpo
- `zizmor .github/workflows/`: 0 high, 0 medium. Sobra o `self-repository` low que já existe na main e passa
- `sf check --allow-commands`: 36 regras, nenhum finding. O `L2.FACTORY_CONFIG_IS_LOCKED` pegou a edição do workflow primeiro, como devia, e o lock foi atualizado no mesmo commit
- `cargo test --release --locked`: 118 passaram
- `sf verify --allow-commands`: 35/35
- `sf docs --check`: sem drift