### PR TITLE
fix(release-plz): stage every derivative the release PR produces

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -104,15 +104,23 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      # `pr` rather than `prs_created`, because a release PR that already
+      # exists and is being refreshed is the case this step most needs to run
+      # for, and `prs_created` answers a narrower question than its name
+      # suggests. The script below treats an absent PR as nothing to do.
       - name: Update the release PR's derived artifacts
-        if: steps.release-plz.outputs.prs_created == 'true'
+        if: steps.release-plz.outputs.pr != ''
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ steps.release-plz.outputs.pr }}
           APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -eu
-          pr_number=$(printf '%s' "$PR" | jq -er '.number')
+          pr_number=$(printf '%s' "$PR" | jq -r '.number // empty')
+          if [ -z "$pr_number" ]; then
+            echo "release-plz reported no release PR to refresh"
+            exit 0
+          fi
           gh pr checkout "$pr_number"
           # `actions/checkout` sets no committer, and `git commit` refuses to
           # guess one. The app's bot account is the honest author: it is what
@@ -126,6 +134,22 @@ jobs:
             echo "release-plz left every derived artifact current"
             exit 0
           fi
-          git add README.md Cargo.lock .software-factory/catalog.lock.json .software-factory/ratchet.yaml docs
+          # Every directory the script writes into, not a list of files
+          # somebody remembered. That list went stale on its first real run:
+          # `sf lock` also writes `.software-factory/locks/`, it was not
+          # named, and the release PR arrived with Cargo.toml bumped and its
+          # dependency lock left behind. `sf fixtures` writes
+          # `.software-factory/mutations/` and was one change from the same.
+          git add README.md Cargo.lock .software-factory docs
           git commit -m "chore: refresh release derivatives"
+          # The `sf check` at the end of the script cannot catch that class of
+          # mistake: it reads the working tree, where the file was correct, and
+          # the omission was in the index. So the tree is asserted clean after
+          # the commit. Anything still dirty here is a derivative this step
+          # produced and did not ship.
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "these release derivatives were produced and not committed:" >&2
+            git status --porcelain >&2
+            exit 1
+          fi
           git push

--- a/.software-factory/locks/factory.lock.json
+++ b/.software-factory/locks/factory.lock.json
@@ -3,7 +3,7 @@
   "files": {
     ".allowed-root-files": "102b1708337d1303a590f8f0201ea147c4c10bc3b41b8e64650b83de9d34aed5",
     ".githooks/pre-commit": "47642e2f720762fecb49bdaecbe28afec61f6ab1611c14c36cf70e240f18b072",
-    ".github/workflows/release-plz.yml": "d9eec995a3efe21f85a036582128149d9ad3635543c0145aae31462274faa182",
+    ".github/workflows/release-plz.yml": "57bab94b235309c9570defdfe5524a888c65bc83c74d10496ce3963fc693b6a0",
     ".github/workflows/release.yml": "cfbf7dfa023db1c52ef6c9fc5111f7df5e151bdb39a0dc992adaf60011579ec3",
     ".github/workflows/software-factory.yml": "0350f6ff218f228765453461949d2c9b7ce5158c0705a7968c332a7b629f7eab",
     ".software-factory/policy.yaml": "a1bddb926bd1befae06e65f224ad264979b51a01856fce4e71d593353624d09c",


### PR DESCRIPTION
O app funcionou na primeira. release-plz abriu o #51 como `software-factory-release[bot]`, o step de artefatos derivados commitou como esse bot com o id numérico, e o gate rodou no release PR, que era o ponto inteiro de não usar o token do Actions.

E ele ficou vermelho em algo real:

```
✗ critical L2.DEPENDENCIES_CHANGE_DELIBERATELY
    Cargo.lock — a locked file was modified without updating the lock
    Cargo.toml — a locked file was modified without updating the lock
```

## A causa

`sf lock` escreve `.software-factory/locks/dependencies.lock.json` e `factory.lock.json` além do `catalog.lock.json`. O `git add` nomeava só o catalog. Então o commit do bot no #51 saiu com exatamente dois arquivos:

```
8da318e chore: refresh release derivatives
 .software-factory/catalog.lock.json | 2 +-
 README.md                           | 2 +-
```

O bump de versão foi e o lock de dependências ficou no runner. `sf fixtures` escreve `.software-factory/mutations/` e estava na mesma posição, a uma fixture de distância da mesma falha.

Agora a lista são os diretórios em que o script escreve, e não os arquivos que alguém lembrou.

## Por que passou pela verificação do próprio script

Vale guardar. `scripts/prepare-release-pr.sh` termina com `sf check --allow-commands`, que lê a working tree, onde o lock estava certo. A omissão estava no índice, que nenhuma regra vê. Então o step agora afirma tree limpa depois do commit, e qualquer coisa suja ali é um derivado que ele produziu e não subiu.

## Um segundo ajuste

A condição do step passou de `prs_created == 'true'` para `pr` não vazio. Refrescar um release PR que já existe é justamente o caso em que ele mais precisa rodar, e `prs_created` responde uma pergunta mais estreita que o nome sugere. PR ausente agora é tratado como nada a fazer, em vez de um `jq -er` falhando e deixando a main vermelha.

## Verificação local

- `sf check --allow-commands`: 36 regras, nenhum finding. Pelo caminho o `L1.COMMENT_STAYS_SUCCINCT` reclamou de um comentário meu de 8 linhas contra o teto de 6, e o comentário encurtou
- `actionlint`: limpo. `zizmor`: 0 high, 0 medium
- `cargo test --release --locked`: 118. `sf verify --allow-commands`: 35/35. `sf docs --check`: sem drift

## Depois do merge

O push na main faz o release-plz refrescar o #51, e com a condição nova o step de derivados roda, commita os locks que faltaram e o `factory` do #51 deve virar verde. Se não refrescar, dá para empurrar o lock na branch do release à mão.