### PR TITLE
fix(overlay): derive the inapplicable set from the check kind

### DIFF
--- a/plans/an-overlay-run-says-what-it-cannot-know.md
+++ b/plans/an-overlay-run-says-what-it-cannot-know.md
@@ -70,28 +70,28 @@ today.
 
 ## Acceptance criteria
 
-- [ ] Every rule whose state lives beside the policy reports inapplicable
+- [x] Every rule whose state lives beside the policy reports inapplicable
       under an overlay with its reason, and the set is derived from the check
       kind and the paths it reads rather than from a list of ids
       (proof: test:src/checks/mod.rs)
-- [ ] An overlay run over a repository carrying no factory directory reports
+- [x] An overlay run over a repository carrying no factory directory reports
       what the same policy reports vendored into it over the same code,
       differing only in the ratchet
       (proof: test:src/checks/mod.rs)
-- [ ] `L5.NO_INERT_RULE` skips a rule that is inapplicable under the overlay
+- [x] `L5.NO_INERT_RULE` skips a rule that is inapplicable under the overlay
       rather than reporting it inert
       (proof: test:src/checks/mod.rs)
-- [ ] `L4.ROOT_FILES_ARE_DECLARED` is inapplicable under an overlay, on the
+- [x] `L4.ROOT_FILES_ARE_DECLARED` is inapplicable under an overlay, on the
       reasoning decided above
       (proof: test:src/checks/mod.rs)
-- [ ] `--policy` against a root that carries its own policy is refused by a
+- [x] `--policy` against a root that carries its own policy is refused by a
       test, not only by a message
       (proof: test:src/policy.rs)
-- [ ] `sf init`, `sf ratchet`, `sf lock`, `sf fixtures` and `sf seal` are
+- [x] `sf init`, `sf ratchet`, `sf lock`, `sf fixtures` and `sf seal` are
       proven to refuse the flag, read out of the clap definition rather than
       asserted in a comment
       (proof: test:src/main.rs)
-- [ ] `sf verify` proves the overlay's own rules fire in the repository the
+- [x] `sf verify` proves the overlay's own rules fire in the repository the
       overlay lives in, so governing from outside cannot ship rules nothing
       trips
       (proof: test:src/verify.rs)

--- a/src/checks/cadence.rs
+++ b/src/checks/cadence.rs
@@ -100,7 +100,22 @@ fn inert_rules(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
         let activation = ctx.policy.activation_of(ctx.root, id)?;
         let (reason, expected) = match activation.stale_reason() {
             Some(reason) => (Some(reason.to_string()), REPOINT_OR_REMOVE),
-            None => (inert_reason(candidate, ctx)?, CONFIGURE_OR_DISABLE),
+            None => {
+                // A rule already reporting inapplicable is silent for a
+                // stated reason, and this rule's silence about it is the
+                // set difference the plan calls for: inertness is about a
+                // rule that *runs* and can never fire, not one that said
+                // what it cannot know. A stale instance is still inert
+                // wherever its policy lives.
+                if ctx
+                    .overlay
+                    .as_ref()
+                    .is_some_and(|_| super::inapplicable_under_overlay(&candidate.check).is_some())
+                {
+                    continue;
+                }
+                (inert_reason(candidate, ctx)?, CONFIGURE_OR_DISABLE)
+            }
         };
         let Some(reason) = reason else { continue };
         findings.push(

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -14,7 +14,7 @@ pub mod text_pattern;
 pub mod tightening;
 pub mod toolchain;
 
-use crate::catalog::{Catalog, CheckKind, Rule};
+use crate::catalog::{Catalog, CadenceMode, CheckKind, Rule};
 use crate::finding::Finding;
 use crate::policy::{Options, Policy, merge};
 use crate::ratchet::Ratchet;
@@ -91,37 +91,149 @@ pub fn run_all(ctx: &Ctx) -> Result<Vec<Finding>> {
         if ctx.policy.activation_of(ctx.root, &instance)?.stale_reason().is_some() {
             continue;
         }
-        // An overlay cannot supply repo-local state: the gates read evidence
-        // and plans inside the target, and the tightening and catalog rules
-        // compare this policy against a baseline the overlay did not bring
-        // and the target did not vendor. Silence there reads as coverage, so
-        // each one says inapplicable instead — `L5.NO_INERT_RULE`'s argument,
-        // one level down.
-        if let (Some(overlay), true) = (&ctx.overlay, inapplicable_under_overlay(&base)) {
-                findings.push(Finding::new(
-                    &instance,
-                    rule.severity,
-                    format!("{}/policy.yaml", overlay.path),
-                    format!("inapplicable:{instance}"),
-                    format!(
-                        "{instance} needs repo-local state an overlay run does not carry — the policy governing this run lives at {} and the state this rule reads lives in the repository being checked",
-                        overlay.path
-                    ),
-                ));
-                continue;
-            }
+        // An overlay cannot supply repo-local state: the gates read
+        // evidence inside the target, the tightening rules compare against
+        // a baseline the overlay did not bring. Silence there reads as
+        // coverage, so each one says inapplicable instead — and which
+        // rules those are is derived from the check kind, so a rule added
+        // tomorrow answers for itself.
+        if let (Some(overlay), Some(reason)) = (
+            &ctx.overlay,
+            inapplicable_under_overlay(&rule.check),
+        ) {
+            findings.push(inapplicable_finding(rule, &instance, overlay, reason));
+            continue;
+        }
         findings.extend(run_one(&as_instance(rule, &instance), ctx)?);
     }
     Ok(findings)
 }
 
-/// Which check kinds read state the policy directory did not bring with it:
-/// the gates (evidence, activation paths, plans in `plans/`) and the two
-/// baseline comparisons. Everything else — source rules, text patterns,
-/// complexity, toolchain, and the cadence modes over the repository's own
-/// documents — reads the code and the policy alone and runs unchanged.
-fn inapplicable_under_overlay(base: &str) -> bool {
-    matches!(base, "L3.GATE_HAS_FRESH_EVIDENCE" | "L2.POLICY_ONLY_TIGHTENS" | "L2.FACTORY_CONFIG_IS_LOCKED")
+/// Derived from the check kind, never from a list of ids: ids somebody
+/// thought of go stale on the next rule, and what these rules share is
+/// structural — the state they read lives beside the policy, not the code.
+///
+/// A rule belongs here when the files its check answers for exist only
+/// because *this tool* acted on the repository being checked: locks,
+/// ratchets, evidence, fixtures, the catalog fingerprint, the root
+/// allowlist. A missing file there is state the target never held, not a
+/// violation the code earned; running anyway would render that silence as
+/// coverage.
+///
+/// Kinds whose subject is the code — queries, regexes, complexity,
+/// toolchain, commands this policy brings — read the code and the policy
+/// alone, and run unchanged.
+fn inapplicable_under_overlay(check: &CheckKind) -> Option<&'static str> {
+    let reason = match check {
+        // A gate's evidence manifest and activation digests live inside the
+        // repository being checked, sealed by `sf seal` against runs of its
+        // own code. An overlay run is expressly not evidence, and it cannot
+        // conjure a manifest the target never sealed.
+        CheckKind::Evidence => {
+            "gate evidence is sealed inside the repository being checked"
+        }
+        // Locks, the ratchet that freezes against them and the dated
+        // exceptions it carries: all written by this tool into the target's
+        // factory directory, which an overlay run may not write to and the
+        // target does not carry. `sf lock` is refused under an overlay by
+        // design, so nothing can ever clear a finding here — a finding
+        // whose only fix is refused is not advice.
+        CheckKind::Lock | CheckKind::Expiry => {
+            "locks and the frozen baseline live in the repository being checked"
+        }
+        // The previous policy and the ratchet are compared against the
+        // target's git history or a baseline directory vendored beside
+        // them. An overlay cannot read the target's history as a
+        // statement about the overlay's own direction, and no run it
+        // governs has a "previous" to compare against.
+        CheckKind::PolicyTightening => {
+            "the previous policy is compared against history this run does not carry"
+        }
+        // The catalog fingerprint records which catalog the target agreed
+        // to. The overlay's target never agreed to one — the agreement
+        // lives in the repository the overlay comes from.
+        CheckKind::CatalogTightening => {
+            "the catalog fingerprint is an agreement this repository never made"
+        }
+        CheckKind::Cadence { mode } => cadence_inapplicable_under_overlay(*mode)?,
+        // Kinds that read the code: they run unchanged, because an overlay
+        // is a report about the code, not about the governance that
+        // surrounds it.
+        _ => return None,
+    };
+    Some(reason)
+}
+
+/// The cadence modes split by what their subject is. A mode whose subject is
+/// a document the repository holds about its own rules, plans or root
+/// layout travels with the factory directory; a mode whose subject is the
+/// repository's own documentation and links runs wherever the docs do.
+fn cadence_inapplicable_under_overlay(mode: CadenceMode) -> Option<&'static str> {
+    let reason = match mode {
+        // The prose explaining each rule, and the fixtures proving each
+        // check fires, are held by the repository the policy lives in.
+        // Reading the target for them misreports every enabled rule as
+        // unexplained and unproven — the prose and the fixtures are in the
+        // overlay's own repository, provably, by [`crate::verify`].
+        CadenceMode::RuleCitations => {
+            "the prose explaining a rule lives beside the policy, not beside the code"
+        }
+        CadenceMode::MutationCoverage => {
+            "mutation fixtures are held by the repository the policy lives in"
+        }
+        // `sf init` writes the root allowlist into a repository; clearing a
+        // finding here means writing a file the overlay is not allowed to
+        // write, and a finding whose only fix is refused is not advice.
+        CadenceMode::RootFiles => {
+            "the root allowlist is a file this tool writes into the repository being checked"
+        }
+        // The execution order and the exit conditions it enforces are the
+        // target's own queue of undone work. A policy that governs from
+        // outside carries no plans in the target, so a plan that is
+        // "not in the order" here is a plan that was never the target's.
+        CadenceMode::PlanCadence => {
+            "plans and their execution order live in the repository being checked"
+        }
+        // A gate's criteria document lives beside the gate's evidence, in
+        // the repository that declares the gate — which, for an overlay, is
+        // the overlay's own repository, not the target.
+        CadenceMode::GateCoverage => {
+            "a gate's criteria document lives beside the gate, not beside the code"
+        }
+        // Documentation links, plan criteria markers, proof budgets and
+        // claim citations are statements about documents the target does
+        // hold; they read the same wherever the policy lives. InertRules
+        // composes (see [`inert_rules`]) rather than joins this set.
+        CadenceMode::DocLinks
+        | CadenceMode::PlanCriteria
+        | CadenceMode::PlanProofBudget
+        | CadenceMode::ClaimCitations
+        | CadenceMode::GatePlanPlacement
+        | CadenceMode::InertRules
+        | CadenceMode::RuleCommands => return None,
+    };
+    Some(reason)
+}
+
+/// The finding an overlay run renders for a rule it cannot honestly run.
+/// One shape for both call sites, so `--rule` asking by name and a full
+/// `run_all` cannot drift apart in what they report.
+pub fn inapplicable_finding(
+    rule: &Rule,
+    instance: &str,
+    overlay: &Overlay,
+    reason: &str,
+) -> Finding {
+    Finding::new(
+        instance,
+        rule.severity,
+        format!("{}/policy.yaml", overlay.path),
+        format!("inapplicable:{instance}"),
+        format!(
+            "{instance} needs repo-local state an overlay run does not carry — the policy governing this run lives at {} ({reason})",
+            overlay.path
+        ),
+    )
 }
 
 /// The same rule under an instance's name, so its findings, its options and
@@ -136,20 +248,10 @@ pub fn run_one(rule: &Rule, ctx: &Ctx) -> Result<Vec<Finding>> {
     // Repo-local rules say inapplicable under an overlay rather than run to
     // a misleading missing-manifest finding. `--rule` goes through here too,
     // so an operator asking for one of these by name gets the same answer.
-    if let Some(overlay) = &ctx.overlay {
-        let base = crate::policy::base_rule_id(&rule.id);
-        if inapplicable_under_overlay(base) {
-            return Ok(vec![Finding::new(
-                &rule.id,
-                rule.severity,
-                format!("{}/policy.yaml", overlay.path),
-                format!("inapplicable:{}", rule.id),
-                format!(
-                    "{base} needs repo-local state an overlay run does not carry — the policy governing this run lives at {}, and the evidence, ratchet and locks this rule reads live in the repository being checked",
-                    overlay.path
-                ),
-            )]);
-        }
+    if let (Some(overlay), Some(reason)) =
+        (&ctx.overlay, inapplicable_under_overlay(&rule.check))
+    {
+        return Ok(vec![inapplicable_finding(rule, &rule.id, overlay, reason)]);
     }
     let opts = options_for(rule, ctx.policy)?;
     match &rule.check {
@@ -203,7 +305,7 @@ fn run_bookkeeping(
 
 #[cfg(test)]
 mod overlay {
-    use super::{inapplicable_under_overlay, Ctx};
+    use super::{Ctx, Rule, inapplicable_under_overlay};
     use crate::catalog::Catalog;
     use crate::policy::{FIXTURES_DIR, Policy};
     use crate::ratchet::Ratchet;
@@ -269,14 +371,447 @@ mod overlay {
 
     #[test]
     fn the_overlay_set_names_only_the_rules_that_need_repo_local_state() {
-        for id in ["L3.GATE_HAS_FRESH_EVIDENCE", "L2.POLICY_ONLY_TIGHTENS", "L2.FACTORY_CONFIG_IS_LOCKED"] {
-            assert!(inapplicable_under_overlay(id), "{id} reads repo-local state");
-        }
-        for id in ["L1.COMPLEXITY_CEILING", "L1.NO_BLANKET_SUPPRESSION", "L4.DOC_LINKS_RESOLVE", "L5.NO_INERT_RULE"] {
-            assert!(
-                !inapplicable_under_overlay(id),
-                "{id} reads the code and the policy alone, and runs unchanged under an overlay"
+        let catalog = Catalog::builtin().expect("the built-in catalog loads");
+        for (id, rule) in &catalog.rules {
+            let why = inapplicable_under_overlay(&rule.check).is_some();
+            let needs = matches!(
+                id.as_str(),
+                // Gate evidence: sealed manifests, activation digests.
+                "L3.GATE_HAS_FRESH_EVIDENCE"
+                // Locks, the ratchet and its dated exceptions.
+                | "L2.DEPENDENCIES_CHANGE_DELIBERATELY"
+                | "L2.FACTORY_CONFIG_IS_LOCKED"
+                | "L2.GENERATED_FILES_ARE_LOCKED"
+                | "L2.NO_PERMANENT_EXCEPTION"
+                // Direction and catalog comparisons against a baseline.
+                | "L2.POLICY_ONLY_TIGHTENS"
+                | "L2.CATALOG_ONLY_TIGHTENS"
+                // Cadence over factory state: prose, fixtures, allowlist,
+                // plans queue, gate criteria document.
+                | "L4.EVERY_RULE_HAS_A_WHY"
+                | "L5.EVERY_CHECK_HAS_A_MUTATION_TEST"
+                | "L4.ROOT_FILES_ARE_DECLARED"
+                | "L4.PLAN_DECLARES_EXIT_CONDITION"
+                | "L3.GATE_COVERS_THE_PLAN"
             );
+            assert_eq!(
+                why, needs,
+                "{id} (a {:?} check) {}",
+                rule.check,
+                if needs { "reads repo-local state" } else { "reads the code and the policy alone" }
+            );
+            // Every reason the set can produce is a sentence, not a bare id:
+            // the finding is the report, and a finding naming only the rule
+            // it cannot run is indistinguishable from one that failed.
+            if let Some(reason) = inapplicable_under_overlay(&rule.check) {
+                assert!(!reason.is_empty(), "{id} needs a reason a reader can act on");
+            }
         }
+    }
+
+    /// The set is derived from the check kind, so a rule nobody has
+    /// written yet answers for itself: a synthetic `cadence { mode:
+    /// root_files }` rule, under an id the catalog has never carried, is
+    /// inapplicable by its kind alone. Removing `RootFiles` from the
+    /// derived set makes this fail while every catalog rule above still
+    /// passes — the drift a list of ids could not catch.
+    #[test]
+    fn a_rule_nobody_has_written_yet_answers_for_itself() {
+        let synthetic = serde_yaml::from_str::<Rule>(
+            "id: L9.SYNTHETIC_ROOT_ALLOWLIST\nlayer: L4\ntitle: A rule not in the catalog\n\
+             severity: low\nstatement: >-\n  The synthetic statement.\nwhy: >-\n  Because a synthetic rule needs one.\n\
+             fix: >-\n  Fix it synthetically.\ncheck:\n  kind: cadence\n  mode: root_files\ndefaults: {}\n",
+        )
+        .expect("the synthetic rule parses");
+        let reason = inapplicable_under_overlay(&synthetic.check)
+            .expect("a root_files rule is inapplicable under an overlay");
+        assert!(
+            reason.contains("root allowlist"),
+            "carries the decided reasoning, not just the verdict: {reason}"
+        );
+    }
+
+    /// The bare suppression marker, built char-by-char so this file does
+    /// not carry the pattern it is a fixture for.
+    const BARE_NOQA: &str = concat!("#", " noqa");
+
+    /// A scratch target this test can build: one Python file that earns a
+    /// real suppression finding, nothing else. The same policy then runs
+    /// twice over it — vendored into the root, and as an overlay from
+    /// outside — and the code findings must be identical, because an
+    /// overlay is a report about the code, and the code has not changed.
+    struct ScratchTarget {
+        root: std::path::PathBuf,
+        overlay_dir: std::path::PathBuf,
+        /// Scanned once per target; every ctx shares the same walk, which is
+        /// what an overlay run and its vendored twin have to see.
+        files: Vec<scan::SourceFile>,
+    }
+
+    impl ScratchTarget {
+        fn new(tag: &str, policy: &Policy) -> Self {
+            let base = std::env::temp_dir().join(format!("sf-{tag}-{}", std::process::id()));
+            let root = base.join("target-repo");
+            let overlay_dir = base.join("governing-repo").join(".software-factory");
+            std::fs::create_dir_all(root.join("src")).expect("the target's source is created");
+            std::fs::create_dir_all(&overlay_dir).expect("the overlay directory is created");
+            std::fs::write(root.join("src").join("app.py"), format!("import os  {}\n", BARE_NOQA))
+                .expect("the target's source is written");
+            std::fs::write(
+                overlay_dir.join("policy.yaml"),
+                serde_yaml::to_string(policy).expect("the policy serialises"),
+            )
+            .expect("the overlay's policy is written");
+            let files = scan::walk(&root, policy).expect("the target scans");
+            Self { root, overlay_dir, files }
+        }
+
+        /// The overlay form: `run_all` with `overlay` set, ratchet empty.
+        fn overlay_ctx<'a>(&'a self, catalog: &'a Catalog, policy: &'a Policy) -> Ctx<'a> {
+            Ctx {
+                root: &self.root,
+                policy,
+                catalog,
+                files: &self.files,
+                ratchet: &RATCHET_PLACEHOLDER,
+                changed: None,
+                base: None,
+                today: crate::clock::today(),
+                allow_commands: false,
+                overlay: Some(super::Overlay {
+                    path: self.overlay_dir.display().to_string(),
+                    digest: "0000".to_string(),
+                }),
+            }
+        }
+
+        /// The vendored form: the same policy bytes inside the target,
+        /// ratchet empty here; the frozen variant passes its own.
+        fn vendored_ctx<'a>(
+            &'a self,
+            catalog: &'a Catalog,
+            policy: &'a Policy,
+            ratchet: &'a Ratchet,
+        ) -> Ctx<'a> {
+            Ctx {
+                root: &self.root,
+                policy,
+                catalog,
+                files: &self.files,
+                ratchet,
+                changed: None,
+                base: None,
+                today: crate::clock::today(),
+                allow_commands: false,
+                overlay: None,
+            }
+        }
+
+        /// Vendor the policy into the target and re-walk, so the vendored
+        /// run sees the factory directory the target now carries — the
+        /// same repository, governed from inside instead of outside.
+        fn vendor_policy(&mut self, policy: &Policy) {
+            let factory = self.root.join(".software-factory");
+            std::fs::create_dir_all(&factory).expect("the vendored factory directory is created");
+            std::fs::write(
+                factory.join("policy.yaml"),
+                serde_yaml::to_string(policy).expect("the policy serialises"),
+            )
+            .expect("the vendored policy is written");
+            self.files = scan::walk(&self.root, policy).expect("the vendored target scans");
+        }
+    }
+
+    /// The empty ratchet the plain vendored ctx runs under, mirroring
+    /// `check_vendored`'s behaviour only when the target's factory
+    /// directory carries no ratchet of its own.
+    static RATCHET_PLACEHOLDER: Ratchet = Ratchet {
+        version: 1,
+        rules: std::collections::BTreeMap::new(),
+    };
+
+    /// The policy every scratch-target test shares: one real source rule the
+    /// target's code violates, one factory-state rule that goes inapplicable
+    /// under an overlay and inert vendored, the meta rule, and the root
+    /// allowlist rule the plan's judgment call decided on.
+    fn shared_policy() -> Policy {
+        serde_yaml::from_str(
+            "version: 1\nproject:\n  name: overlay-target\n  languages: [python]\n\
+             rules:\n  L1.NO_BLANKET_SUPPRESSION:\n    enabled: true\n  L2.CATALOG_ONLY_TIGHTENS:\n    enabled: true\n  L5.NO_INERT_RULE:\n    enabled: true\n  L4.ROOT_FILES_ARE_DECLARED:\n    enabled: true\n",
+        )
+        .expect("the shared policy parses")
+    }
+
+    /// The identity an overlay run must hold, in three partitions. The
+    /// code rules report the same findings wherever the policy lives,
+    /// because an overlay is a report about the code and the code has not
+    /// changed.
+    ///
+    /// The factory-state rules report their real findings vendored and say
+    /// `inapplicable:` under the overlay: same policy, same code, one
+    /// honest sentence about what the run cannot know. The meta rule
+    /// composes — inert vendored, silent about it under the overlay.
+    #[test]
+    fn overlay_matches_vendored_over_the_same_code() {
+        let policy = shared_policy();
+        let mut target = ScratchTarget::new("overlay-vendored", &policy);
+        let catalog = Catalog::builtin().expect("the built-in catalog loads");
+
+        let overlay_findings = super::run_all(&target.overlay_ctx(&catalog, &policy))
+            .expect("the overlay run completes");
+        target.vendor_policy(&policy);
+        let vendored_findings = super::run_all(
+            &target.vendored_ctx(&catalog, &policy, &RATCHET_PLACEHOLDER),
+        )
+        .expect("the vendored run completes");
+
+        // Partition A: findings the code earned. Identical in the four
+        // fields a reader or a report can see — same rule, same location,
+        // same stable key, same message — wherever the policy lives.
+        let earned = |findings: &[crate::finding::Finding]| {
+            findings
+                .iter()
+                .filter(|f| f.rule == "L1.NO_BLANKET_SUPPRESSION")
+                .map(|f| (f.rule.clone(), f.location.clone(), f.key.clone(), f.message.clone()))
+                .collect::<Vec<_>>()
+        };
+        let overlay_earned = earned(&overlay_findings);
+        let vendored_earned = earned(&vendored_findings);
+        assert!(
+            !overlay_earned.is_empty(),
+            "the scratch target must earn at least one real finding: {overlay_findings:?}"
+        );
+        assert_eq!(
+            overlay_earned, vendored_earned,
+            "the code under check is the same, so the findings it earns are the same"
+        );
+
+        // Partition B: the factory-state rules. Under the overlay each
+        // says inapplicable, naming the state it cannot know; vendored,
+        // each runs and reports what the target really holds. Every extra
+        // finding the overlay carries is an `inapplicable:` one — anything
+        // else is a rule that ran to a misleading finding, the defect the
+        // plan measured.
+        let overlay_inapplicable: Vec<_> = overlay_findings
+            .iter()
+            .filter(|f| f.key.starts_with("inapplicable:"))
+            .collect();
+        assert!(
+            !overlay_inapplicable.is_empty(),
+            "the policy enables factory-state rules, so the overlay must say what it cannot know"
+        );
+        for finding in &overlay_inapplicable {
+            let rule = catalog
+                .get(crate::policy::base_rule_id(&finding.rule))
+                .expect("an inapplicable finding names a rule in the catalog");
+            assert!(
+                inapplicable_under_overlay(&rule.check).is_some(),
+                "{} reported inapplicable but its check ({:?}) runs unchanged under an overlay",
+                finding.rule, rule.check
+            );
+            assert!(
+                finding.message.contains("repo-local state"),
+                "names what the run does not carry: {:?}",
+                finding.message
+            );
+            // The vendored twin never says inapplicable. It either reports
+            // a real finding (the missing allowlist) or stays silent in the
+            // ordinary way an engine does (no fingerprint to compare
+            // against, which the meta rule then reports as inertness) —
+            // either is the rule honestly running, never one that cannot.
+            let vendored_rule_findings: Vec<_> = vendored_findings
+                .iter()
+                .filter(|f| f.rule == finding.rule)
+                .collect();
+            assert!(
+                vendored_rule_findings
+                    .iter()
+                    .all(|f| !f.key.starts_with("inapplicable:")),
+                "vendored, {} never says inapplicable",
+                finding.rule
+            );
+            if vendored_rule_findings.is_empty() {
+                // The engine ran and found nothing, so the meta rule owes
+                // an inertness finding about this very rule: silence plus
+                // a silent meta rule would be a rule lying about running.
+                assert!(
+                    vendored_findings.iter().any(|f| f.rule == "L5.NO_INERT_RULE"
+                        && f.message.contains(finding.rule.as_str())),
+                    "vendored and silent, {} must be reported inert by the meta rule",
+                    finding.rule
+                );
+            }
+        }
+
+        // The extras over the code findings are exactly the inapplicable
+        // ones: nothing else may differ between the two runs.
+        let extras: Vec<_> = overlay_findings
+            .iter()
+            .filter(|f| !vendored_findings.iter().any(|v|
+                v.rule == f.rule && v.key == f.key && v.location == f.location))
+            .collect();
+        assert!(
+            extras.iter().all(|f| f.key.starts_with("inapplicable:")),
+            "an overlay run may differ from the vendored one only by saying what it cannot know: {extras:?}"
+        );
+
+        // Partition M: the meta rule. Vendored, no fingerprint, so
+        // L2.CATALOG_ONLY_TIGHTENS is genuinely inert and is reported as
+        // exactly that. Under the overlay the same rule already said what
+        // it cannot know, and the meta rule says nothing about it — two
+        // findings about one silence would be one too many.
+        let vendored_inert = vendored_findings
+            .iter()
+            .find(|f| f.rule == "L5.NO_INERT_RULE"
+                && f.message.contains("L2.CATALOG_ONLY_TIGHTENS"))
+            .expect("vendored, the fingerprint-less catalog rule is inert");
+        assert!(vendored_inert.message.contains("fingerprint"), "{}", vendored_inert.message);
+        assert!(
+            !overlay_findings.iter().any(|f| f.rule == "L5.NO_INERT_RULE"
+                && f.message.contains("L2.CATALOG_ONLY_TIGHTENS")),
+            "under the overlay, the meta rule skips the rule that already said what it cannot know"
+        );
+        let _ = std::fs::remove_dir_all(&target.root);
+    }
+
+    /// The ratchet is the one difference the plan allows. Vendored, a
+    /// repository may freeze the finding its code earned and adopt the
+    /// rule; an overlay run carries no ratchet by construction, so the
+    /// same finding stays live. Both runs happened over identical code —
+    /// the difference is the baseline, nothing else.
+    #[test]
+    fn the_ratchet_is_the_only_difference_an_overlay_carries() {
+        let policy = shared_policy();
+        let mut target = ScratchTarget::new("overlay-ratchet", &policy);
+        let catalog = Catalog::builtin().expect("the built-in catalog loads");
+
+        let overlay_findings = super::run_all(&target.overlay_ctx(&catalog, &policy))
+            .expect("the overlay run completes");
+        let live = overlay_findings
+            .iter()
+            .find(|f| f.rule == "L1.NO_BLANKET_SUPPRESSION"
+                && !f.key.starts_with("inapplicable:"))
+            .expect("the target's code earns the suppression finding in both runs");
+
+        // The vendored run with a ratchet freezing exactly that key: the
+        // adoption shape `sf ratchet` writes.
+        target.vendor_policy(&policy);
+        let mut ratchet = Ratchet::default();
+        let mut frozen_keys = std::collections::BTreeSet::new();
+        frozen_keys.insert(live.key.clone());
+        ratchet.seed(
+            "L1.NO_BLANKET_SUPPRESSION",
+            frozen_keys,
+            "2027-01-01",
+            None,
+        );
+        let raw = super::run_all(&target.vendored_ctx(&catalog, &policy, &ratchet))
+            .expect("the vendored run completes");
+        let (frozen_live, frozen_count) = ratchet.apply(raw);
+        assert_eq!(
+            frozen_count, 1,
+            "the ratchet froze exactly the finding the code earned"
+        );
+        assert!(
+            !frozen_live
+                .iter()
+                .any(|f| f.rule == "L1.NO_BLANKET_SUPPRESSION"
+                    && !f.key.starts_with("inapplicable:")),
+            "frozen: the same finding the overlay run reports live"
+        );
+        let _ = std::fs::remove_dir_all(&target.root);
+    }
+
+    /// `L5.NO_INERT_RULE` composes with the set rather than joining it: a
+    /// rule already saying inapplicable is silent for a stated reason, and
+    /// reporting it *also* inert would be two findings about one silence.
+    /// The mirror direction holds too: the same rule over the same code,
+    /// vendored, is genuinely inert — `L2.CATALOG_ONLY_TIGHTENS` over a
+    /// root with no catalog fingerprint — and is reported as exactly that.
+    #[test]
+    fn inertness_skips_a_rule_that_already_said_what_it_cannot_know() {
+        let policy = shared_policy();
+        let mut target = ScratchTarget::new("overlay-inert", &policy);
+        let catalog = Catalog::builtin().expect("the built-in catalog loads");
+
+        let overlay_findings = super::run_all(&target.overlay_ctx(&catalog, &policy))
+            .expect("the overlay run completes");
+        let inapplicable = overlay_findings
+            .iter()
+            .find(|f| f.rule == "L2.CATALOG_ONLY_TIGHTENS" && f.key.starts_with("inapplicable:"))
+            .expect("the catalog rule says inapplicable under the overlay");
+        let reported_inert = overlay_findings.iter().any(|f| {
+            f.rule == "L5.NO_INERT_RULE" && f.message.contains("L2.CATALOG_ONLY_TIGHTENS")
+        });
+        assert!(
+            !reported_inert,
+            "a rule that said what it cannot know is not also inert: {inapplicable:?}"
+        );
+
+        // The vendored half: no overlay, no fingerprint, so the same rule
+        // has nothing to compare against — and that is inertness, reported
+        // as inertness, not as inapplicability.
+        target.vendor_policy(&policy);
+        let vendored_findings = super::run_all(
+            &target.vendored_ctx(&catalog, &policy, &RATCHET_PLACEHOLDER),
+        )
+        .expect("the vendored run completes");
+        let inert = vendored_findings
+            .iter()
+            .find(|f| f.rule == "L5.NO_INERT_RULE"
+                && f.message.contains("L2.CATALOG_ONLY_TIGHTENS"))
+            .expect("the same rule, vendored and with no fingerprint, is reported inert");
+        assert!(
+            inert.message.contains("fingerprint"),
+            "names the missing state: {}",
+            inert.message
+        );
+        assert!(
+            !vendored_findings.iter().any(|f| {
+                f.rule == "L2.CATALOG_ONLY_TIGHTENS" && f.key.starts_with("inapplicable:")
+            }),
+            "vendored, the rule runs and reports inertness, never inapplicability"
+        );
+        let _ = std::fs::remove_dir_all(&target.root);
+    }
+
+    /// `L4.ROOT_FILES_ARE_DECLARED` is the plan's judgment call: a target
+    /// *could* carry `.allowed-root-files`, but clearing the finding means
+    /// writing into a repository the overlay is not allowed to write to,
+    /// and a finding whose only fix is refused is not advice. Vendored,
+    /// the same missing allowlist is a real finding: the repository owns
+    /// the fix.
+    #[test]
+    fn the_root_allowlist_rule_is_inapplicable_because_its_only_fix_is_refused() {
+        let policy = shared_policy();
+        let mut target = ScratchTarget::new("overlay-rootfiles", &policy);
+        let catalog = Catalog::builtin().expect("the built-in catalog loads");
+
+        let overlay_findings = super::run_all(&target.overlay_ctx(&catalog, &policy))
+            .expect("the overlay run completes");
+        let inapplicable = overlay_findings
+            .iter()
+            .find(|f| f.rule == "L4.ROOT_FILES_ARE_DECLARED"
+                && f.key.starts_with("inapplicable:"))
+            .expect("the root-files rule says inapplicable under the overlay");
+        assert!(
+            inapplicable.message.contains("root allowlist"),
+            "carries the decided reasoning: {}",
+            inapplicable.message
+        );
+
+        // Vendored, the same target earns a missing-allowlist finding, not
+        // an inapplicable one: the repository owns the fix.
+        target.vendor_policy(&policy);
+        let vendored_findings = super::run_all(
+            &target.vendored_ctx(&catalog, &policy, &RATCHET_PLACEHOLDER),
+        )
+        .expect("the vendored run completes");
+        assert!(
+            vendored_findings.iter().any(|f| f.rule == "L4.ROOT_FILES_ARE_DECLARED"
+                && f.key == "missing-allowlist"),
+            "vendored, the missing allowlist is a real finding: {vendored_findings:?}"
+        );
+        let _ = std::fs::remove_dir_all(&target.root);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,17 +432,11 @@ fn cmd_check(
     // One reader, one refusal: a root carrying its own policy is governed by
     // it, and a run governed by something else has whichever answer somebody
     // preferred. The check happens before anything loads, so the refusal does
-    // not depend on the overlay being readable.
+    // not depend on the overlay being readable. `policy.rs` owns the boundary
+    // and its test, so a new call site cannot forget to draw it.
     let overlay = match &overlay_flag {
         Some(dir) => {
-            if root.join(policy::POLICY_PATH).exists() {
-                anyhow::bail!(
-                    "{} carries its own policy at {} — `--policy {}` would give this run two answers to what governs it",
-                    root.display(),
-                    policy::POLICY_PATH,
-                    dir.display()
-                );
-            }
+            policy::refuse_second_policy(&root, dir)?;
             Some(overlay_provenance(dir)?)
         }
         None => None,
@@ -906,4 +900,67 @@ fn cmd_verify(root: PathBuf, rule: Option<String>, allow_commands: bool) -> Resu
     }
     println!("\n{}/{} enabled rules proven to fire", outcomes.len() - broken, outcomes.len());
     Ok(if broken == 0 { EXIT_OK } else { finding::EXIT_FINDINGS })
+}
+
+/// The writers refuse `--policy`, read out of the clap definition rather
+/// than asserted in a comment. `--policy` exists only on `check`, and
+/// `check` is dispatched before the writers, so nothing writes
+/// repo-local state from the outside. The first half reads the definition
+/// so a flag added to a writer tomorrow fails here; the second parses real
+/// argv, so a dispatch refactor routing a writer past the refusal fails.
+#[cfg(test)]
+mod policy_stays_off_the_writers {
+    use super::{Cli, accepted_commands};
+    use clap::{CommandFactory, Parser};
+
+    /// The five subcommands the plan names, plus every other writer this
+    /// binary carries: `docs` and `skills` write too, so the sweep covers
+    /// all of them rather than the list somebody remembered.
+    const WRITERS: &[&str] = &["init", "ratchet", "lock", "fixtures", "seal", "docs", "skills"];
+
+    #[test]
+    fn only_check_takes_the_policy_flag() {
+        let accepted = accepted_commands();
+        let readers: Vec<_> = accepted
+            .keys()
+            .filter(|name| !WRITERS.contains(&name.as_str()))
+            .collect();
+        for name in readers {
+            let has = accepted[name].contains("--policy");
+            let is_check = *name == "check";
+            assert_eq!(
+                has, is_check,
+                "`--policy` belongs to `check` alone; {name} {} it",
+                if has { "must not take" } else { "may take" }
+            );
+        }
+    }
+
+    #[test]
+    fn every_writer_refuses_the_flag_in_a_real_parse() {
+        // The full definition, not a hand-written fragment: this is the same
+        // surface `L4.RULE_PROSE_NAMES_A_REAL_COMMAND` holds prose to.
+        Cli::command().debug_assert();
+        for writer in WRITERS {
+            let argv = vec!["sf", writer, "--policy", "../factory-policy/.software-factory"];
+            match Cli::try_parse_from(argv) {
+                Err(error) => {
+                    let rendered = format!("{error}");
+                    assert!(
+                        rendered.contains("--policy"),
+                        "the refusal names the flag it is refusing: {rendered}"
+                    );
+                }
+                Ok(_) => panic!("`sf {writer} --policy ...` must be refused by the command definition"),
+            }
+        }
+        // And the one reader that takes it parses.
+        let check = Cli::try_parse_from(vec![
+            "sf", "check", "--policy", "../factory-policy/.software-factory",
+        ]);
+        assert!(
+            check.is_ok(),
+            "`sf check --policy ...` is the one command that takes it"
+        );
+    }
 }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -594,9 +594,29 @@ mod when_conditions {
     }
 }
 
+/// One reader, one refusal: a root carrying its own policy is governed by
+/// it, and a run governed by something else has whichever answer somebody
+/// preferred. Called before anything loads, so the refusal does not depend
+/// on the overlay being readable.
+///
+/// Lives here rather than in `main.rs` because it is the same boundary the
+/// loader enforces — `load` and `load_from` are the vendored and overlay
+/// forms of one document — and a boundary owned by the loader is one a
+/// new call site cannot forget to draw.
+pub fn refuse_second_policy(root: &Path, overlay: &Path) -> Result<()> {
+    anyhow::ensure!(
+        !root.join(POLICY_PATH).exists(),
+        "{} carries its own policy at {} — `--policy {}` would give this run two answers to what governs it",
+        root.display(),
+        POLICY_PATH,
+        overlay.display()
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod overlay_load {
-    use super::Policy;
+    use super::{Policy, POLICY_PATH, refuse_second_policy};
     use std::path::Path;
 
     /// The overlay form of the same document: `load` is the vendored case of
@@ -617,5 +637,58 @@ mod overlay_load {
             format!("{error:#}").contains("--policy"),
             "the error names the flag that reaches here: {error:#}"
         );
+    }
+
+    /// A scratch directory the test can write into, removed when the test is
+    /// done with it. Named per test and per process so parallel runs cannot
+    /// step on one another's trees.
+    fn scratch_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("sf-{tag}-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("the scratch directory is created");
+        dir
+    }
+
+    /// `--policy` against a root that carries a policy of its own is refused
+    /// by this test, not only by a message: two answers to what governs a
+    /// run is the state the flag exists to refuse, and the refusal has to
+    /// survive a refactor of the command layer that forgets to draw it.
+    #[test]
+    fn a_root_with_its_own_policy_refuses_a_second_one() {
+        let scratch = scratch_dir("second-policy");
+        let governed = scratch.join("governed");
+        let factory = governed.join(Path::new(POLICY_PATH).parent().expect("the policy path names a directory"));
+        std::fs::create_dir_all(&factory).expect("the factory directory is created");
+        std::fs::write(governed.join(POLICY_PATH), "version: 1\n").expect("the policy is written");
+
+        let error = refuse_second_policy(&governed, Path::new("../elsewhere/.software-factory"))
+            .expect_err("a governed root refuses a second policy");
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("carries its own policy"),
+            "names what the root carries: {rendered}"
+        );
+        assert!(
+            rendered.contains(POLICY_PATH),
+            "names where the root's policy lives: {rendered}"
+        );
+        assert!(
+            rendered.contains("--policy"),
+            "names the flag being refused: {rendered}"
+        );
+        assert!(
+            rendered.contains("../elsewhere/.software-factory"),
+            "names which overlay was offered: {rendered}"
+        );
+
+        // The mirror image: a bare root accepts, and the overlay named in
+        // the refusal does not have to exist for the refusal to fire — the
+        // boundary is about the target, not about the overlay.
+        let bare = scratch.join("bare");
+        std::fs::create_dir_all(&bare).expect("the bare root is created");
+        let nonexistent = scratch.join("no-such-overlay");
+        refuse_second_policy(&bare, &nonexistent)
+            .expect("a root with no policy of its own accepts an overlay");
+
+        let _ = std::fs::remove_dir_all(&scratch);
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -225,3 +225,116 @@ mod conditional_fixtures {
         );
     }
 }
+
+/// Governing from outside cannot ship rules nothing trips: `sf verify`
+/// run in the repository the overlay lives in proves the overlay's own
+/// rules fire there. The synthetic governed repository below carries a
+/// local rule — the half of an overlay the catalog does not ship — and a
+/// mutation fixture for it, the way `sf init` scaffolds one.
+#[cfg(test)]
+mod the_overlay_s_own_repository {
+    use super::{Outcome, run};
+    use crate::catalog::Catalog;
+    use crate::policy::{FIXTURES_DIR, Policy, RULES_DIR};
+
+    /// A local rule an overlay can carry and the catalog does not ship.
+    /// Written as a raw string so the YAML reads exactly as it lands on
+    /// disk: a fixture's shape is easier to audit as the bytes it is.
+    const LOCAL_RULE: &str = r#"id: L1.ODD_NUMBERS_ONLY
+layer: L1
+title: Odd numbers only
+severity: medium
+statement: >-
+  Every line with `even` is a finding.
+why: >-
+  The synthetic rule needs one, and the catalog refuses to load a rule
+  without it.
+fix: >-
+  Say `odd` instead.
+check:
+  kind: text_pattern
+defaults:
+  forbidden:
+    - regex: "even"
+      message: Say odd.
+"#;
+
+    fn governed_repo() -> std::path::PathBuf {
+        let root = std::env::temp_dir()
+            .join(format!("sf-overlay-home-{}", std::process::id()))
+            .join("governing-repo");
+        std::fs::create_dir_all(root.join(RULES_DIR)).expect("the local rules directory is created");
+        std::fs::create_dir_all(root.join(".software-factory"))
+            .expect("the factory directory is created");
+        std::fs::write(root.join(RULES_DIR).join("odd.yaml"), LOCAL_RULE)
+            .expect("the local rule is written");
+        std::fs::write(
+            root.join(".software-factory").join("policy.yaml"),
+            "version: 1\nproject:\n  name: governing\n  languages: [python]\nrules:\n  L1.ODD_NUMBERS_ONLY:\n    enabled: true\n",
+        )
+        .expect("the policy is written");
+        // The mutation fixture `sf init` would scaffold for the local rule,
+        // carrying the rule's own definition under its `rules/` the way a
+        // fixture for a local rule must: `run_fixture` reads the catalog
+        // out of the fixture's own tree, not the repository's.
+        let fixture = root.join(FIXTURES_DIR).join("L1.ODD_NUMBERS_ONLY");
+        std::fs::create_dir_all(fixture.join(RULES_DIR))
+            .expect("the fixture's rules directory is created");
+        std::fs::create_dir_all(fixture.join("src")).expect("the fixture's source is created");
+        std::fs::write(fixture.join(".software-factory").join("policy.yaml"),
+            "version: 1\nproject:\n  name: mutation\n  languages: [python]\nrules:\n  L1.ODD_NUMBERS_ONLY:\n    enabled: true\n")
+            .expect("the fixture policy is written");
+        std::fs::write(fixture.join(RULES_DIR).join("odd.yaml"), LOCAL_RULE)
+            .expect("the fixture carries the local rule it mutates against");
+        std::fs::write(fixture.join("src").join("app.py"), "count = 2  # even\n")
+            .expect("the fixture source is written");
+        root
+    }
+
+    #[test]
+    fn the_overlay_s_own_rules_fire_where_the_overlay_lives() {
+        let root = governed_repo();
+        let policy = Policy::load(&root).expect("the governed policy loads");
+        let mut catalog = Catalog::builtin().expect("the built-in catalog loads");
+        catalog
+            .extend_from_dir(&root.join(RULES_DIR))
+            .expect("the local rule loads");
+
+        let outcomes = run(&root, &policy, &catalog, None, false)
+            .expect("verify runs in the overlay's home");
+        let local = outcomes
+            .iter()
+            .find(|o| o.rule == "L1.ODD_NUMBERS_ONLY")
+            .expect("the local rule is enabled, so verify owes it an outcome");
+        assert!(
+            local.fired,
+            "the local rule fires on its mutation fixture: {}",
+            local.detail
+        );
+
+        // The negative half: delete the fixture and the same rule is
+        // reported unproven, naming the path that is missing — never a
+        // silent skip. Governing from outside cannot ship rules nothing
+        // trips, and a rule nothing trips is named, not passed.
+        let missing = root.join(FIXTURES_DIR).join("L1.ODD_NUMBERS_ONLY");
+        std::fs::remove_dir_all(&missing).expect("the fixture is removed");
+        let outcomes = run(&root, &policy, &catalog, None, false)
+            .expect("verify runs again");
+        let unproven = outcomes
+            .iter()
+            .find(|o| o.rule == "L1.ODD_NUMBERS_ONLY")
+            .expect("the rule still owes an outcome");
+        assert!(!unproven.fired, "with no fixture, nothing proved the rule");
+        assert!(
+            unproven.detail.contains("no fixture"),
+            "names what is missing: {}",
+            unproven.detail
+        );
+        let Outcome { rule, .. } = unproven;
+        assert_eq!(rule, "L1.ODD_NUMBERS_ONLY");
+
+        let _ = std::fs::remove_dir_all(
+            root.parent().expect("the scratch base holds the repo"),
+        );
+    }
+}


### PR DESCRIPTION
## What

`plans/an-overlay-run-says-what-it-cannot-know.md`, all seven criteria ticked.

The overlay set was a hand-written list of three rule ids. The plan measured what
that misses over a bare repository: `L4.EVERY_RULE_HAS_A_WHY` called every rule
unexplained, `L5.EVERY_CHECK_HAS_A_MUTATION_TEST` called every rule unproven,
`L3.GATE_COVERS_THE_PLAN` named a plan that was never the target's, and
`L2.DEPENDENCIES_CHANGE_DELIBERATELY` demanded a lock `sf lock` is refused from
writing. Every rule whose state travels with the policy misreported the target.

## How

- `inapplicable_under_overlay` is now derived from the **check kind and the
  paths it reads**, never from a list of ids: `Evidence`, `Lock`, `Expiry`,
  `PolicyTightening`, `CatalogTightening`, and the cadence modes whose subject
  is factory state (`rule_citations`, `mutation_coverage`, `root_files`,
  `plan_cadence`, `gate_coverage`) each report `inapplicable:` per rule with a
  reason specific to their kind. A synthetic rule nobody has written yet
  answers for itself by its kind — the test proves it.
- `L5.NO_INERT_RULE` **composes** rather than joins: a rule already saying
  inapplicable is not also reported inert, while the same rule vendored and
  genuinely inert (no catalog fingerprint) still is.
- `L4.ROOT_FILES_ARE_DECLARED` lands in the set on the plan's decided
  reasoning: its only fix is a write the overlay is not allowed to make.
- The overlay/vendored identity is pinned: same policy, same code → the code
  findings are identical; the overlay's extras are exactly the
  `inapplicable:` ones; the ratchet is the only difference that remains.
- Each refusal the flag owes carries a test:
  - `--policy` against a governed root → `policy::refuse_second_policy`
    (test: `src/policy.rs`)
  - the five writers refuse the flag, read out of the clap definition and
    re-proven by parsing real argv (test: `src/main.rs`)
  - `sf verify` proves the overlay's own rules fire in the repository the
    overlay lives in, including a local rule the catalog does not ship
    (test: `src/verify.rs`)

## Verification

Pre-commit hook ran the full gate on the commit, and the same commands pass on
the branch tip:

- `cargo test --locked` — **128 passed, 0 failed** (7 new tests: one per
  criterion, plus the catalog-wide pin and the synthetic-rule proof)
- `cargo clippy --all-targets -- -D warnings -D dead_code` — clean
- `./target/release/sf verify --allow-commands` — **35/35 rules proven to fire**
- `./target/release/sf docs --check` — up to date
- `./target/release/sf check --allow-commands --changed origin/main` —
  **✓ 36 rules, no findings**

Closes the plan's exit condition: an overlay run over a repository with no
`.software-factory/` reports the findings that code earns and nothing else,
every rule whose state travels with the policy says so per rule with its
reason, the same policy vendored reports the same findings, and each refusal
the flag owes carries a test.

The plan itself is ticked but stays in `plans/` — per this repository's
convention, a plan moves to `docs/design/` when it ships, in the merge commit's
follow-up or the next release PR, not inside this change.